### PR TITLE
Add Breadcrumbs navigation component

### DIFF
--- a/_stories/molecules/Breadcrumbs/README.md
+++ b/_stories/molecules/Breadcrumbs/README.md
@@ -1,0 +1,136 @@
+# Breadcrumbs
+
+### **NOTE**: The component will only render with a minimum width of **991px**
+
+The `<Breadcrumbs>` component creates navigation links for the current pathname based on a configuration object.
+
+[See the prototype here](https://ds.gumgum.com/stable/).
+
+## Props
+
+| name           | description                                                                                                                                                  | required |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| config         | Object that defines the app routes. See below for details.                                                                                                   | true     |
+| pathname       | Current pathname either from react-router or window.location.pathname                                                                                        | true     |
+| hideMenus      | Boolean attribute to prevent displaying subpath submenus                                                                                                     | false    |
+| hideRoot       | Boolean attribute to prevent displaying the Root element (only if other breadcrumbs are available)                                                           | false    |
+| linkComponent  | Optional component to display as the breadcrumbs. Receives prop "to" as its href                                                                             | false    |
+| titleDecorator | Optional function for transforming titles when defaulting to the path. By default will Capitalize first letter and replace dashes and underscores for spaces | false    |
+
+## Configuration
+
+The configuration is simply an object that represents the app's routes:
+
+| property | description                                                                                                                                     | required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| title    | String to display in breadcrumbs and submenus Defaults to capitalized slug.                                                                     | false    |
+| path     | Path value on the URL. Prepend with ":" to treat pathname value as parameters (ie /posts/:id). **Only one parameter is allowed for each level** | true     |
+| subpaths | Optional Array containing objects of the same shape (title, path, subpaths)                                                                     | false    |
+
+### Configuration Example:
+
+```
+const routes = {
+    title: 'Home', // Root title
+    path: 'home', // Root path is optional, defaults to '/'
+    subpaths: [ // Children paths
+        {
+            title: 'Main Category', // Children Title
+            path: 'category', // Children
+            subpaths: [
+                { // Each subpath group can specify one parameter
+                    path: ':categoryId'
+                },
+                { // Or multiple specific paths
+                    title: 'Sub Category 1', // Grand children title
+                    path: 'subcategory-1' //Grand children path
+                },
+                {
+                    title: 'Sub Category 2',
+                    path: 'subcategory-2'
+                },
+                {
+                    title: 'Sub Category 3',
+                    path: 'subcategory-3'
+                },
+            ]
+        },
+        {
+            path: 'products', // The title will default to "Products"
+            subpaths: [
+                {
+                    path: ':id', // The value will be treated as a parameter, the title is optional
+                    subpaths: [ // Add as many subpaths as you need!
+                        {
+                            path: 'edit'
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+```
+
+## Usage
+
+### Using link component provided by the library:
+
+```
+render() {
+    const pathname = '/products/12/edit';
+    return (
+        <header className="gds-page-header">
+            <div className="gds-page-header__nav-bar">
+                <Breadcrumbs pathname={pathname} config={routes} />
+            </div>
+        </header>
+    );
+}
+```
+
+### Passing a custom component and removing submenus:
+
+```
+const CustomLink = (props) => (
+    <a href={props.to} >
+        {props.children}
+    </a>
+);
+
+render() {
+    const pathname = '/products/12/edit';
+    return (
+        <header className="gds-page-header">
+            <div className="gds-page-header__nav-bar">
+                <Breadcrumbs
+                    pathname={pathname}
+                    config={routes}
+                    linkComponent={CustomLink}
+                    hideMenus />
+            </div>
+        </header>
+    );
+}
+```
+
+### Passing a custom title decorator and hiding the root breadcrumb:
+
+```
+_decorateTitle = (title) => title.toUpperCase();
+
+render() {
+    const pathname = '/products/12/edit';
+    return (
+        <header className="gds-page-header">
+            <div className="gds-page-header__nav-bar">
+                <Breadcrumbs
+                    pathname={pathname}
+                    config={routes}
+                    titleDecorator={this._decorateTitle}
+                    hideRoot />
+            </div>
+        </header>
+    );
+}
+```

--- a/_stories/molecules/Breadcrumbs/index.js
+++ b/_stories/molecules/Breadcrumbs/index.js
@@ -1,0 +1,104 @@
+import React, { Component } from 'react';
+import { select, boolean } from '@storybook/addon-knobs';
+
+import readme from './README.md';
+import Breadcrumbs from '../../../components/molecules/Breadcrumbs';
+
+const config = {
+    title: 'Home',
+    path: 'home',
+    subpaths: [
+        {
+            title: 'Main Category',
+            path: 'category',
+            subpaths: [
+                {
+                    title: 'Sub Category 1',
+                    path: 'subcategory-1'
+                },
+                {
+                    title: 'Sub Category 2',
+                    path: 'subcategory-2'
+                },
+                {
+                    title: 'Sub Category 3',
+                    path: 'subcategory-3'
+                }
+            ]
+        },
+        {
+            title: 'Products',
+            path: 'products',
+            subpaths: [
+                {
+                    path: ':id',
+                    subpaths: [
+                        {
+                            path: 'edit'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            path: ':pageId'
+        },
+        {
+            path: 'publishers',
+            subpaths: [
+                {
+                    path: ':id'
+                }
+            ]
+        },
+        {
+            path: 'zone',
+            subpaths: [
+                {
+                    path: ':id'
+                }
+            ]
+        }
+    ]
+};
+
+class BreadcrumbsStory extends Component {
+    static displayName = 'Breadcrumbs';
+
+    state = {
+        hideSubmenus: false
+    };
+
+    render() {
+        return (
+            <header className="gds-page-header">
+                <div className="gds-page-header__nav-bar">
+                    <Breadcrumbs
+                        config={config}
+                        pathname={select('pathname', routeOptions, routeOptions[0])}
+                        hideMenus={boolean('Hide Submenus', false)}
+                        hideRoot={boolean('Hide root breadcrumb', false)}
+                    />
+                </div>
+            </header>
+        );
+    }
+}
+
+const routeOptions = [
+    '/',
+    '/home',
+    '/home/static-page',
+    '/home/category',
+    '/home/category/subcategory-1',
+    '/home/category/subcategory-2',
+    '/home/category/subcategory-3',
+    '/home/products/42',
+    '/home/products/42/edit',
+    '/home/products/stringId',
+    '/home/products/stringId/edit'
+];
+
+const component = () => <BreadcrumbsStory />;
+
+export default [readme, component];

--- a/_stories/molecules/index.js
+++ b/_stories/molecules/index.js
@@ -6,6 +6,7 @@ import { withInfo } from '@storybook/addon-info';
 
 import Accordion from './Accordion';
 import Avatar from './Avatar/';
+import Breadcrumbs from './Breadcrumbs/';
 import Card from './Card/';
 import CardBlock from './CardBlock/';
 import CardImage from './CardImage/';
@@ -21,9 +22,7 @@ import Toggle from './Toggle/';
 import Well from './Well/';
 
 const stories = storiesOf('Molecules', module);
-const storyWrapper = story => {
-    return <div style={{ margin: '35px' }}>{story()}</div>;
-};
+const storyWrapper = story => <div style={{ margin: '35px' }}>{story()}</div>;
 
 stories
     .addDecorator((story, context) => withInfo('')(story)(context))
@@ -31,6 +30,7 @@ stories
     .addDecorator(withKnobs)
     .add('Accordion', withReadme(...Accordion))
     .add('Avatar', withReadme(...Avatar))
+    .add('Breadcrumbs', withReadme(...Breadcrumbs))
     .add('Card', withReadme(...Card))
     .add('CardBlock', withReadme(...CardBlock))
     .add('CardImage', withReadme(...CardImage))

--- a/components/index.js
+++ b/components/index.js
@@ -29,6 +29,7 @@ export { default as Row } from './layout/Row';
 // Export Molecules
 export { default as Accordion } from './molecules/Accordion';
 export { default as Avatar } from './molecules/Avatar';
+export { default as Breadcrumbs } from './molecules/Breadcrumbs';
 export { default as CardBlock } from './molecules/CardBlock';
 export { default as CardImage } from './molecules/CardImage';
 export { default as Card } from './molecules/Card';

--- a/components/molecules/Breadcrumb.jsx
+++ b/components/molecules/Breadcrumb.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import BreadcrumbMenu from './BreadcrumbMenu';
+
+const baseClass = 'gds-page-header__breadcrumbs-list-item';
+const filterMenu = pathname => ({ path }) => path.charAt(0) !== ':' && !pathname.includes(path);
+
+const Breadcrumb = props => {
+    const {
+        config: { title, path, subpaths },
+        linkComponent: LinkComponent,
+        pathname,
+        hideMenus,
+        isLast,
+        className
+    } = props;
+    const hasSubpaths = !hideMenus && subpaths && subpaths.length;
+    const menu = hasSubpaths && subpaths.filter(filterMenu(pathname));
+    const hasMenu = !!(menu && menu.length);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--has-menu`]: hasMenu
+    });
+
+    return (
+        <li className={rootClass}>
+            {hasMenu && <BreadcrumbMenu linkComponent={LinkComponent} menu={menu} path={path} />}
+            {isLast ? (
+                title
+            ) : (
+                <LinkComponent className="gds-page-header__breadcrumbs-link" to={path}>
+                    {title}
+                </LinkComponent>
+            )}
+        </li>
+    );
+};
+
+Breadcrumb.displayName = 'Breadcrumb';
+
+Breadcrumb.propTypes = {
+    linkComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+    config: PropTypes.shape({
+        title: PropTypes.string.isRequired,
+        path: PropTypes.string.isRequired,
+        subpaths: PropTypes.array
+    }).isRequired,
+    pathname: PropTypes.string.isRequired,
+    isLast: PropTypes.bool.isRequired,
+    hideMenus: PropTypes.bool,
+    className: PropTypes.string
+};
+
+export default Breadcrumb;

--- a/components/molecules/BreadcrumbLink.jsx
+++ b/components/molecules/BreadcrumbLink.jsx
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const BreadcrumbLink = ({ children, to, className }) => (
+    <a className={className} href={to}>
+        {children}
+    </a>
+);
+
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+BreadcrumbLink.propTypes = {
+    to: PropTypes.string.isRequired
+};
+
+export default BreadcrumbLink;

--- a/components/molecules/BreadcrumbMenu.jsx
+++ b/components/molecules/BreadcrumbMenu.jsx
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+class BreadcrumbMenu extends Component {
+    static displayName = 'BreadcrumbMenu';
+
+    static propTypes = {
+        path: PropTypes.string.isRequired,
+        menu: PropTypes.arrayOf(
+            PropTypes.shape({
+                title: PropTypes.string,
+                path: PropTypes.string.isRequired
+            })
+        ).isRequired,
+        linkComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
+    };
+
+    state = {
+        showMenu: false
+    };
+
+    _toggleMenu = () => this.setState(({ showMenu }) => ({ showMenu: !showMenu }));
+
+    render() {
+        const { showMenu } = this.state;
+        const { path: parentPath, linkComponent: LinkComponent, menu } = this.props;
+        const menuClass = cx('gds-bubble__menu', 'gds-bubble__menu--left', 'gds-bubble__menu--sm', {
+            'gds-bubble__menu--menu-open': showMenu
+        });
+
+        return (
+            <div onClick={this._toggleMenu} className="gds-page-header__breadcrumbs-menu">
+                <div className="gds-page-header__breadcrumbs-menu-dots" />
+                <div className={menuClass}>
+                    <ul className="gds-bubble__menu-list">
+                        {menu.map(({ title, path }) => (
+                            <li key={path} className="gds-bubble__menu-list-item -ellipsis">
+                                <LinkComponent
+                                    className="gds-bubble__menu-list-link -text-tr-cap"
+                                    to={`${parentPath}/${path}`}>
+                                    {title || path}
+                                </LinkComponent>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+                <span> </span>
+            </div>
+        );
+    }
+}
+
+export default BreadcrumbMenu;

--- a/components/molecules/Breadcrumbs.jsx
+++ b/components/molecules/Breadcrumbs.jsx
@@ -1,0 +1,128 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import Breadcrumb from './Breadcrumb';
+import BreadcrumbLink from './BreadcrumbLink';
+
+class Breadcrumbs extends Component {
+    static displayName = 'Breadcrumbs';
+
+    static defaultProps = {
+        linkComponent: BreadcrumbLink,
+        titleDecorator: title =>
+            title.replace(/^\w/, chr => chr.toUpperCase()).replace(/-|_/g, ' '),
+        hideMenus: false,
+        hideRoot: false
+    };
+
+    static propTypes = {
+        linkComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+        config: PropTypes.shape({
+            title: PropTypes.string.isRequired,
+            path: PropTypes.string,
+            subpaths: PropTypes.array
+        }).isRequired,
+        pathname: PropTypes.string.isRequired,
+        titleDecorator: PropTypes.func,
+        hideMenus: PropTypes.bool,
+        hideRoot: PropTypes.bool
+    };
+
+    // Create the full path for the current slug based on the previous entry
+    _buildHref = (arr, slug) => {
+        const previous = arr && arr[arr.length - 1];
+        const newPath = previous ? `${previous.path}/${slug}` : slug;
+        return newPath.replace('//', '/');
+    };
+
+    // Create a title for parameters, either the capitalized param or a number
+    _getParamTitle = param =>
+        Number.isInteger(parseInt(param)) ? param : this.props.titleDecorator(param);
+
+    // Creates a flat Array only with the nodes that correspond to the current pathname
+    // It includes replaces the path with the full path to each link
+    _findTrail = (pathname, config) => {
+        const initialBreadcrumb = {
+            title: config.title || '/',
+            path: config.path.charAt(0) === '/' ? config.path : `/${config.path || ''}`
+        };
+
+        // Set initial data if necessary
+        const initialData =
+            config.path === '/'
+                ? [initialBreadcrumb]
+                : [
+                      {
+                          title: config.title || '/',
+                          path: config.path
+                      }
+                  ];
+        const searchBreakpoints = (pathSections, subpaths, accumulator = []) =>
+            pathSections.reduce((trail, pathSection, index) => {
+                // Find current path subpathData
+                const subpathData = subpaths.find(({ path }) => path === pathSection);
+                // Find section param subpathData if no exact path was found
+                const paramData =
+                    !subpathData && subpaths.find(({ path }) => path.charAt(0) === ':');
+                const breadcrumbData = subpathData || paramData;
+                const acceptBreadcrumb = trail.length < maxLength;
+                // Push section subpathData  to accumulator
+                if (acceptBreadcrumb && breadcrumbData) {
+                    // Set defaults depending on type of path (param or regular path)
+                    const breadcrumbPath = paramData ? pathSection : breadcrumbData.path;
+                    const breadcrumbTitle =
+                        breadcrumbData.title || this._getParamTitle(pathSection);
+                    // Build full path for link
+                    const currentPath = this._buildHref(trail, breadcrumbPath);
+                    trail.push({
+                        ...breadcrumbData,
+                        path: currentPath,
+                        title: breadcrumbTitle
+                    });
+                }
+                const trailContinues = trail.length < maxLength;
+                // Go deeper if there are subpaths
+                if (subpathData && trailContinues) {
+                    const nextIndex = index + 1;
+                    const remainingParts = pathSections.slice(nextIndex);
+                    // Search for the remaining pathname parts on the current path's subpaths,
+                    return searchBreakpoints(remainingParts, subpathData.subpaths, trail);
+                }
+                return trail;
+            }, accumulator);
+
+        // Divide pathname into sections
+        const parts = pathname.split('/').filter(Boolean);
+        const duplicateRoot = parts[0] === config.path;
+        const initialSections = duplicateRoot ? parts.slice(1) : parts;
+        const maxLength = duplicateRoot ? initialSections.length + 1 : initialSections.length;
+        // Compare pathname parts against user provided configuration
+        const breadcrumbs = searchBreakpoints(initialSections, config.subpaths, initialData);
+        return breadcrumbs;
+    };
+
+    render() {
+        const { config, linkComponent, hideRoot, hideMenus, pathname } = this.props;
+        const breadcrumbs = this._findTrail(pathname, config);
+        const displayBreadcrumbs =
+            hideRoot && breadcrumbs.length > 1 ? breadcrumbs.slice(1) : breadcrumbs;
+        return (
+            <div className="gds-page-header__breadcrumb-nav">
+                <ul className="gds-page-header__breadcrumbs">
+                    {displayBreadcrumbs.map((path, index, arr) => (
+                        <Breadcrumb
+                            key={path.path}
+                            hideMenus={hideMenus}
+                            linkComponent={linkComponent}
+                            config={path}
+                            pathname={pathname}
+                            isLast={arr.length - 1 === index}
+                        />
+                    ))}
+                </ul>
+            </div>
+        );
+    }
+}
+
+export default Breadcrumbs;


### PR DESCRIPTION
This PR will add the Breadcrumbs component, the prototype can be found here:

https://ds.gumgum.com/stable/

The component has optional submenus, [please see the component's README](https://github.com/gumgum/gumdrops/blob/6a75a4b2420cc11e71c4bab0662950312fdc0085/_stories/molecules/Breadcrumbs/README.md) for more details.

Make sure that the central panel in storybook has enough space (more than 991px) otherwise the component won't render (DS defaults)