### PR TITLE
Fix missing breadcrumb pathnames without root

### DIFF
--- a/_stories/molecules/Breadcrumbs/index.js
+++ b/_stories/molecules/Breadcrumbs/index.js
@@ -3,8 +3,38 @@ import { select, boolean } from '@storybook/addon-knobs';
 
 import readme from './README.md';
 import Breadcrumbs from '../../../components/molecules/Breadcrumbs';
+import Button from '../../../components/atoms/Button';
 
-const config = {
+const optionsA = [
+    '/',
+    '/home',
+    '/home/static-page',
+    '/home/category',
+    '/home/category/subcategory-1',
+    '/home/category/subcategory-2',
+    '/home/category/subcategory-3',
+    '/home/products/42',
+    '/home/products/42/edit',
+    '/home/products/stringId',
+    '/home/products/stringId/edit'
+];
+
+const optionsB = [
+    '/publishers',
+    '/publishers/42',
+    '/publishers/42/settings',
+    '/publishers/42/financials',
+    '/publishers/42/zones',
+    '/publishers/42/performance',
+    '/publishers/42/users',
+    '/publishers/42/activity-log',
+    '/zones',
+    '/zones/woop',
+    '/zones/woop/overview',
+    '/zones/woop/overview/settings'
+];
+
+const configA = {
     title: 'Home',
     path: 'home',
     subpaths: [
@@ -42,17 +72,45 @@ const config = {
         },
         {
             path: ':pageId'
-        },
+        }
+    ]
+};
+
+const configB = {
+    title: 'Start',
+    path: '/',
+    subpaths: [
         {
             path: 'publishers',
             subpaths: [
                 {
-                    path: ':id'
+                    path: ':id',
+                    subpaths: [
+                        {
+                            path: 'settings'
+                        },
+                        {
+                            path: 'financials'
+                        },
+                        {
+                            path: 'zones'
+                        },
+                        {
+                            path: 'performance'
+                        },
+                        {
+                            path: 'users'
+                        },
+                        {
+                            path: 'activity-log',
+                            title: 'Activity Log'
+                        }
+                    ]
                 }
             ]
         },
         {
-            path: 'zone',
+            path: 'zones',
             subpaths: [
                 {
                     path: ':id'
@@ -62,42 +120,55 @@ const config = {
     ]
 };
 
+const configSelect = {
+    A: 'A',
+    B: 'B'
+};
+
+const configs = {
+    A: configA,
+    B: configB
+};
+
+const options = {
+    A: optionsA,
+    B: optionsB
+};
+
 class BreadcrumbsStory extends Component {
     static displayName = 'Breadcrumbs';
 
-    state = {
-        hideSubmenus: false
-    };
+    printCode = code => '\n' + JSON.stringify(code, null, 4) + '\n\n';
 
     render() {
+        const selectedConfig = select('Configuration', configSelect, configSelect['A']);
+
+        const configTitle = `// Configuration ${selectedConfig}:`;
+
         return (
-            <header className="gds-page-header">
-                <div className="gds-page-header__nav-bar">
-                    <Breadcrumbs
-                        config={config}
-                        pathname={select('pathname', routeOptions, routeOptions[0])}
-                        hideMenus={boolean('Hide Submenus', false)}
-                        hideRoot={boolean('Hide root breadcrumb', false)}
-                    />
-                </div>
-            </header>
+            <div>
+                <header className="gds-page-header -color-bg-white">
+                    <div className="gds-page-header__nav-bar">
+                        <Breadcrumbs
+                            config={configs[selectedConfig]}
+                            pathname={select(
+                                'Pathname',
+                                options[selectedConfig],
+                                options[selectedConfig][1]
+                            )}
+                            hideMenus={boolean('Hide submenus', false)}
+                            hideRoot={boolean('Hide root breadcrumb', false)}
+                        />
+                    </div>
+                </header>
+                <pre className="-m-t-6">
+                    {configTitle}
+                    {this.printCode(configs[selectedConfig])}
+                </pre>
+            </div>
         );
     }
 }
-
-const routeOptions = [
-    '/',
-    '/home',
-    '/home/static-page',
-    '/home/category',
-    '/home/category/subcategory-1',
-    '/home/category/subcategory-2',
-    '/home/category/subcategory-3',
-    '/home/products/42',
-    '/home/products/42/edit',
-    '/home/products/stringId',
-    '/home/products/stringId/edit'
-];
 
 const component = () => <BreadcrumbsStory />;
 

--- a/components/molecules/Breadcrumbs.jsx
+++ b/components/molecules/Breadcrumbs.jsx
@@ -82,11 +82,11 @@ class Breadcrumbs extends Component {
                 }
                 const trailContinues = trail.length < maxLength;
                 // Go deeper if there are subpaths
-                if (subpathData && trailContinues) {
+                if (breadcrumbData && breadcrumbData.subpaths && trailContinues) {
                     const nextIndex = index + 1;
                     const remainingParts = pathSections.slice(nextIndex);
                     // Search for the remaining pathname parts on the current path's subpaths,
-                    return searchBreakpoints(remainingParts, subpathData.subpaths, trail);
+                    return searchBreakpoints(remainingParts, breadcrumbData.subpaths, trail);
                 }
                 return trail;
             }, accumulator);
@@ -95,7 +95,7 @@ class Breadcrumbs extends Component {
         const parts = pathname.split('/').filter(Boolean);
         const duplicateRoot = parts[0] === config.path;
         const initialSections = duplicateRoot ? parts.slice(1) : parts;
-        const maxLength = duplicateRoot ? initialSections.length + 1 : initialSections.length;
+        const maxLength = initialSections.length + 1;
         // Compare pathname parts against user provided configuration
         const breadcrumbs = searchBreakpoints(initialSections, config.subpaths, initialData);
         return breadcrumbs;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gumdrops",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "GumGum's React Components Library",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
This addresses an issue where pathnames that didn't specify a root path (for example: `/home` ) would not show the last part of the trail.

I also added a two configurations to the story to be able to test them on the fly, one  that sets a `/home` root path and one without it and also different routes.