### PR TITLE
Add BreadcrumbsWrapper for unopinionated breadcrumbs

### DIFF
--- a/_stories/molecules/Breadcrumbs/README.md
+++ b/_stories/molecules/Breadcrumbs/README.md
@@ -2,7 +2,7 @@
 
 ### **NOTE**: The component will only render with a minimum width of **991px**
 
-The `<Breadcrumbs>` component creates navigation links for the current pathname based on a configuration object.
+The `<Breadcrumbs>` component creates navigation links for the current pathname based on an opinionated configuration object. The idea behind this component is to drop it anywhere with minimal or no configuration and get breadcrumbs generated automatically. The only required prop is a pathname, but a config object is also accepted for fine tuning. The library also has a `<BreadcrumbsWrapper>` component if you need to customize the implementation yourself.
 
 [See the prototype here](https://ds.gumgum.com/stable/).
 
@@ -10,8 +10,8 @@ The `<Breadcrumbs>` component creates navigation links for the current pathname 
 
 | name           | description                                                                                                                                                  | required |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| config         | Object that defines the app routes. See below for details.                                                                                                   | true     |
 | pathname       | Current pathname either from react-router or window.location.pathname                                                                                        | true     |
+| config         | Object that defines the app routes. See below for details.                                                                                                   | false    |
 | hideMenus      | Boolean attribute to prevent displaying subpath submenus                                                                                                     | false    |
 | hideRoot       | Boolean attribute to prevent displaying the Root element (only if other breadcrumbs are available)                                                           | false    |
 | linkComponent  | Optional component to display as the breadcrumbs. Receives prop "to" as its href                                                                             | false    |
@@ -74,7 +74,7 @@ const routes = {
 
 ## Usage
 
-### Using link component provided by the library:
+### No configuration object passed, the component will generate breadcrumbs based on the pathname prop:
 
 ```
 render() {
@@ -82,14 +82,14 @@ render() {
     return (
         <header className="gds-page-header">
             <div className="gds-page-header__nav-bar">
-                <Breadcrumbs pathname={pathname} config={routes} />
+                <Breadcrumbs pathname={pathname} />
             </div>
         </header>
     );
 }
 ```
 
-### Passing a custom component and removing submenus:
+### Passing a configuration object, custom component and hiding submenus:
 
 ```
 const CustomLink = (props) => (

--- a/_stories/molecules/Breadcrumbs/index.js
+++ b/_stories/molecules/Breadcrumbs/index.js
@@ -122,39 +122,48 @@ const configB = {
 
 const configSelect = {
     A: 'A',
-    B: 'B'
+    B: 'B',
+    C: 'C'
 };
 
 const configs = {
     A: configA,
-    B: configB
+    B: configB,
+    C: undefined
 };
 
 const options = {
     A: optionsA,
-    B: optionsB
+    B: optionsB,
+    C: [...optionsA, ...optionsB]
 };
 
 class BreadcrumbsStory extends Component {
     static displayName = 'Breadcrumbs';
 
-    printCode = code => '\n' + JSON.stringify(code, null, 4) + '\n\n';
+    printCode = code => (code ? '\n' + JSON.stringify(code, null, 4) + '\n\n' : '');
 
     render() {
         const selectedConfig = select('Configuration', configSelect, configSelect['A']);
 
-        const configTitle = `// Configuration ${selectedConfig}:`;
+        const noConfig = selectedConfig === 'C';
+
+        const configTitle = `//${noConfig ? ' No' : ''} Configuration${
+            noConfig ? '' : ' ' + (selectedConfig + ':')
+        }`;
+
+        const config = configs[selectedConfig];
 
         return (
             <div>
                 <header className="gds-page-header -color-bg-white">
                     <div className="gds-page-header__nav-bar">
                         <Breadcrumbs
-                            config={configs[selectedConfig]}
+                            config={config}
                             pathname={select(
                                 'Pathname',
                                 options[selectedConfig],
-                                options[selectedConfig][1]
+                                options[selectedConfig][0]
                             )}
                             hideMenus={boolean('Hide submenus', false)}
                             hideRoot={boolean('Hide root breadcrumb', false)}

--- a/_stories/molecules/BreadcrumbsWrapper/README.md
+++ b/_stories/molecules/BreadcrumbsWrapper/README.md
@@ -1,0 +1,77 @@
+# BreadcrumbsWrapper
+
+### **NOTE**: The component will only render with a minimum width of **991px**
+
+**See the `<Breadcrumbs/>` component for an opinionated plug and play version**
+
+The `<BreadcrumbsWrapper>` component helps when you need more customization than what the `<Breadcrumbs/>` component provides, use it together with the `<Breadcrumb>` component to get the desired styles or pass your own.
+
+## BreadcrumbsWrapper Props
+
+| name     | description                                | required |
+| -------- | ------------------------------------------ | -------- |
+| children | React components to display as breadcrumbs | true     |
+
+## Breadcrumb Props
+
+| name          | description                                                                                           | required |
+| ------------- | ----------------------------------------------------------------------------------------------------- | -------- |
+| path          | Value to use for the link href or react-router's `to` prop.                                           | true     |
+| linkComponent | Optional component to display as the breadcrumbs. Receives prop "to" as its href                      | true     |
+| title         | String to display in breadcrumbs and submenus Defaults to capitalized slug.                           | false    |
+| pathname      | Optional current pathname value, used to filter out the current pathname from submenus.               | false    |
+| subpaths      | Optional Array containing objects of the same shape (title, path, subpaths), used to display submenus | false    |
+| noLink        | Optional boolean that will display the title as text without link                                     | false    |
+
+## Usage
+
+### Create a custom array of breadcrumbs and pass it to the component:
+
+```
+class Header extends Component {
+    state = {
+        breadcrumbs: [
+            {
+                title: 'Home',
+                to: '/'
+            },
+            {
+                title: 'Publishers',
+                to: '/publishers'
+            },
+            {
+                title: 'Some Publisher',
+                to: '/publishers/123'
+            },
+            {
+                title: 'Random Page',
+                to: '/random-route/123'
+            }
+        ]
+    };
+
+    render() {
+        const { breadcrumbs } = this.state;
+
+        return (
+            <div>
+                <header className="gds-page-header -color-bg-white">
+                    <div className="gds-page-header__nav-bar">
+                        <BreadcrumbsWrapper>
+                            {breadcrumbs.map(({ title, to }, index) => (
+                                <Breadcrumb
+                                    key={to}
+                                    linkComponent={Link}
+                                    title={title}
+                                    path={to}
+                                    isLast={index === breadcrumbs.length - 1}
+                                />
+                            ))}
+                        </BreadcrumbsWrapper>
+                    </div>
+                </header>
+            </div>
+        );
+    }
+}
+```

--- a/_stories/molecules/BreadcrumbsWrapper/index.js
+++ b/_stories/molecules/BreadcrumbsWrapper/index.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import { select, boolean } from '@storybook/addon-knobs';
+
+import readme from './README.md';
+import BreadcrumbsWrapper from '../../../components/molecules/BreadcrumbsWrapper';
+import Breadcrumb from '../../../components/molecules/Breadcrumb';
+import Link from '../../../components/molecules/BreadcrumbLink';
+import Button from '../../../components/atoms/Button';
+
+class BreadcrumbsWrapperStory extends Component {
+    static displayName = 'BreadcrumbsWrapper';
+
+    state = {
+        breadcrumbs: [
+            {
+                title: 'Home',
+                to: '/'
+            },
+            {
+                title: 'Publishers',
+                to: '/publishers'
+            },
+            {
+                title: 'Johnny Pub',
+                to: '/publishers/123'
+            },
+            {
+                title: 'Random Page',
+                to: '/random-route/123'
+            },
+            {
+                title: 'Settings',
+                to: '/publishers/123/settings'
+            }
+        ]
+    };
+
+    render() {
+        const { breadcrumbs } = this.state;
+
+        return (
+            <div>
+                <header className="gds-page-header -color-bg-white">
+                    <div className="gds-page-header__nav-bar">
+                        <BreadcrumbsWrapper>
+                            {breadcrumbs.map(({ title, to }, index) => (
+                                <Breadcrumb
+                                    key={to}
+                                    linkComponent={Link}
+                                    title={title}
+                                    path={to}
+                                    isLast={index === breadcrumbs.length - 1}
+                                />
+                            ))}
+                        </BreadcrumbsWrapper>
+                    </div>
+                </header>
+            </div>
+        );
+    }
+}
+
+const component = () => <BreadcrumbsWrapperStory />;
+
+export default [readme, component];

--- a/_stories/molecules/index.js
+++ b/_stories/molecules/index.js
@@ -7,6 +7,7 @@ import { withInfo } from '@storybook/addon-info';
 import Accordion from './Accordion';
 import Avatar from './Avatar/';
 import Breadcrumbs from './Breadcrumbs/';
+import BreadcrumbsWrapper from './BreadcrumbsWrapper/';
 import Card from './Card/';
 import CardBlock from './CardBlock/';
 import CardImage from './CardImage/';
@@ -31,6 +32,7 @@ stories
     .add('Accordion', withReadme(...Accordion))
     .add('Avatar', withReadme(...Avatar))
     .add('Breadcrumbs', withReadme(...Breadcrumbs))
+    .add('BreadcrumbsWrapper', withReadme(...BreadcrumbsWrapper))
     .add('Card', withReadme(...Card))
     .add('CardBlock', withReadme(...CardBlock))
     .add('CardImage', withReadme(...CardImage))

--- a/components/index.js
+++ b/components/index.js
@@ -29,7 +29,11 @@ export { default as Row } from './layout/Row';
 // Export Molecules
 export { default as Accordion } from './molecules/Accordion';
 export { default as Avatar } from './molecules/Avatar';
+export { default as Breadcrumb } from './molecules/Breadcrumb';
+export { default as BreadcrumbLink } from './molecules/BreadcrumbLink';
+export { default as BreadcrumbMenu } from './molecules/BreadcrumbMenu';
 export { default as Breadcrumbs } from './molecules/Breadcrumbs';
+export { default as BreadcrumbsWrapper } from './molecules/BreadcrumbsWrapper';
 export { default as CardBlock } from './molecules/CardBlock';
 export { default as CardImage } from './molecules/CardImage';
 export { default as Card } from './molecules/Card';

--- a/components/molecules/Breadcrumb.jsx
+++ b/components/molecules/Breadcrumb.jsx
@@ -9,7 +9,9 @@ const filterMenu = pathname => ({ path }) => path.charAt(0) !== ':' && !pathname
 
 const Breadcrumb = props => {
     const {
-        config: { title, path, subpaths },
+        title,
+        path,
+        subpaths,
         linkComponent: LinkComponent,
         pathname,
         hideMenus,
@@ -22,15 +24,16 @@ const Breadcrumb = props => {
     const rootClass = cx(baseClass, className, {
         [`${baseClass}--has-menu`]: hasMenu
     });
+    const displayTitle = title || path;
 
     return (
         <li className={rootClass}>
             {hasMenu && <BreadcrumbMenu linkComponent={LinkComponent} menu={menu} path={path} />}
             {isLast ? (
-                title
+                displayTitle
             ) : (
                 <LinkComponent className="gds-page-header__breadcrumbs-link" to={path}>
-                    {title}
+                    {displayTitle}
                 </LinkComponent>
             )}
         </li>
@@ -41,12 +44,10 @@ Breadcrumb.displayName = 'Breadcrumb';
 
 Breadcrumb.propTypes = {
     linkComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
-    config: PropTypes.shape({
-        title: PropTypes.string.isRequired,
-        path: PropTypes.string.isRequired,
-        subpaths: PropTypes.array
-    }).isRequired,
-    pathname: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    path: PropTypes.string.isRequired,
+    subpaths: PropTypes.array,
+    pathname: PropTypes.string,
     isLast: PropTypes.bool.isRequired,
     hideMenus: PropTypes.bool,
     className: PropTypes.string

--- a/components/molecules/Breadcrumbs.jsx
+++ b/components/molecules/Breadcrumbs.jsx
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 
 import Breadcrumb from './Breadcrumb';
 import BreadcrumbLink from './BreadcrumbLink';
+import BreadcrumbsWrapper from './BreadcrumbsWrapper';
 
 class Breadcrumbs extends Component {
     static displayName = 'Breadcrumbs';
 
     static defaultProps = {
+        config: { path: '/' },
         linkComponent: BreadcrumbLink,
         titleDecorator: title =>
             title.replace(/^\w/, chr => chr.toUpperCase()).replace(/-|_/g, ' '),
@@ -18,7 +20,7 @@ class Breadcrumbs extends Component {
     static propTypes = {
         linkComponent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
         config: PropTypes.shape({
-            title: PropTypes.string.isRequired,
+            title: PropTypes.string,
             path: PropTypes.string,
             subpaths: PropTypes.array
         }).isRequired,
@@ -60,11 +62,11 @@ class Breadcrumbs extends Component {
         const searchBreakpoints = (pathSections, subpaths, accumulator = []) =>
             pathSections.reduce((trail, pathSection, index) => {
                 // Find current path subpathData
-                const subpathData = subpaths.find(({ path }) => path === pathSection);
+                const subpathData = subpaths && subpaths.find(({ path }) => path === pathSection);
                 // Find section param subpathData if no exact path was found
                 const paramData =
-                    !subpathData && subpaths.find(({ path }) => path.charAt(0) === ':');
-                const breadcrumbData = subpathData || paramData;
+                    !subpathData && subpaths && subpaths.find(({ path }) => path.charAt(0) === ':');
+                const breadcrumbData = subpathData || paramData || { path: pathSection };
                 const acceptBreadcrumb = trail.length < maxLength;
                 // Push section subpathData  to accumulator
                 if (acceptBreadcrumb && breadcrumbData) {
@@ -107,20 +109,20 @@ class Breadcrumbs extends Component {
         const displayBreadcrumbs =
             hideRoot && breadcrumbs.length > 1 ? breadcrumbs.slice(1) : breadcrumbs;
         return (
-            <div className="gds-page-header__breadcrumb-nav">
-                <ul className="gds-page-header__breadcrumbs">
-                    {displayBreadcrumbs.map((path, index, arr) => (
-                        <Breadcrumb
-                            key={path.path}
-                            hideMenus={hideMenus}
-                            linkComponent={linkComponent}
-                            config={path}
-                            pathname={pathname}
-                            isLast={arr.length - 1 === index}
-                        />
-                    ))}
-                </ul>
-            </div>
+            <BreadcrumbsWrapper>
+                {displayBreadcrumbs.map(({ title, path, subpaths }, index, arr) => (
+                    <Breadcrumb
+                        key={path}
+                        hideMenus={hideMenus}
+                        linkComponent={linkComponent}
+                        title={title}
+                        path={path}
+                        subpaths={subpaths}
+                        pathname={pathname}
+                        isLast={arr.length - 1 === index}
+                    />
+                ))}
+            </BreadcrumbsWrapper>
         );
     }
 }

--- a/components/molecules/BreadcrumbsWrapper.jsx
+++ b/components/molecules/BreadcrumbsWrapper.jsx
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+const BreadcrumbsWrapper = ({ children, ...props }) => (
+    <div className="gds-page-header__breadcrumb-nav" {...props}>
+        <ul className="gds-page-header__breadcrumbs">{children}</ul>
+    </div>
+);
+BreadcrumbsWrapper.displayName = 'BreadcrumbsWrapper';
+
+BreadcrumbsWrapper.propTypes = {
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.array]).isRequired
+};
+
+export default BreadcrumbsWrapper;


### PR DESCRIPTION
This PR introduces the BreadcrumbsWrapper component, a stateless components to display any content given to it.

It also makes the configuration object for the Breadcrumbs component optional by setting a default `{path: '/'}`

The stories were modified as well to reflect these changes and also add a the simplest example to use with the Breadcrumbs component.