### PR TITLE
Add DocumentTitle component

### DIFF
--- a/_stories/molecules/DocumentTitle/README.md
+++ b/_stories/molecules/DocumentTitle/README.md
@@ -1,0 +1,58 @@
+The `<DocumentTitle>` component is used to set the document.title value in an easy way.
+
+It can either be used to wrap around content, or as a standalone component that won't render anything and just change the document.title value.
+
+## Props
+
+| name     | description                                | required |
+| -------- | ------------------------------------------ | -------- |
+| title    | String to be used as document.title value. | false    |
+| children | Any Nodes to be rendered.                  | false    |
+
+**Standalone Example**:
+
+```
+state = {
+    id: 123,
+    name: 'The Client'
+};
+
+render() {
+    const { id, name } = this.state;
+    const pageTitle = `${id} | ${name} | My Page`;
+
+    return (
+        <div>
+            <DocumentTitle title={pageTitle} />
+            <p>Some Random content</p>
+        </div>
+    )
+};
+```
+
+Sometimes you may need to set the document title inside a render function, this is where the wrapper is helpful.
+
+**High Order Component Example**:
+
+```
+render() {
+    return (
+        <Route
+            path="/settings"
+            render={() => (
+                <DocumentTitle title="Settings | My Page" >
+                    <p>Settings</p>
+                </DocumentTitle>
+            )}
+        />
+        <Route
+            path="/financials"
+            render={() => (
+                <DocumentTitle title="Financials | My Page" >
+                    <p>Financials</p>
+                </DocumentTitle>
+            )}
+        />
+    )
+};
+```

--- a/_stories/molecules/DocumentTitle/README.md
+++ b/_stories/molecules/DocumentTitle/README.md
@@ -32,7 +32,7 @@ render() {
 
 Sometimes you may need to set the document title inside a render function, this is where the wrapper is helpful.
 
-**High Order Component Example**:
+**Wrapper Example**:
 
 ```
 render() {

--- a/_stories/molecules/DocumentTitle/index.js
+++ b/_stories/molecules/DocumentTitle/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import readme from './README.md';
+import DocumentTitle from '../../../components/molecules/DocumentTitle';
+
+const component = () => <DocumentTitle title="Some random page title" />;
+
+export default [readme, component];

--- a/_stories/molecules/index.js
+++ b/_stories/molecules/index.js
@@ -13,6 +13,7 @@ import CardBlock from './CardBlock/';
 import CardImage from './CardImage/';
 import Checkbox from './Checkbox/';
 import Divider from './Divider/';
+import DocumentTitle from './DocumentTitle/';
 import FormGroup from './FormGroup/';
 import LoginForm from './LoginForm/';
 import MultiSelect from './MultiSelect/';
@@ -38,6 +39,7 @@ stories
     .add('CardImage', withReadme(...CardImage))
     .add('Checkbox', withReadme(...Checkbox))
     .add('Divider', withReadme(...Divider))
+    .add('DocumentTitle', withReadme(...DocumentTitle))
     .add('FormGroup', withReadme(...FormGroup))
     .add('LoginForm', withReadme(...LoginForm))
     .add('Modal', withReadme(...Modal))

--- a/components/index.js
+++ b/components/index.js
@@ -39,6 +39,7 @@ export { default as CardImage } from './molecules/CardImage';
 export { default as Card } from './molecules/Card';
 export { default as Checkbox } from './molecules/Checkbox';
 export { default as Divider } from './molecules/Divider';
+export { default as DocumentTitle } from './molecules/DocumentTitle';
 export { default as FormGroup } from './molecules/FormGroup';
 export { default as LoginForm } from './molecules/LoginForm';
 export { default as Modal } from './molecules/Modal';

--- a/components/molecules/DocumentTitle.jsx
+++ b/components/molecules/DocumentTitle.jsx
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import trimString from '../utils/trimString';
+
+export default class DocumentTitle extends Component {
+    static propTypes = {
+        title: PropTypes.string,
+        children: PropTypes.node
+    };
+
+    componentDidMount() {
+        this._updateTitle(this.props.title);
+    }
+
+    componentDidUpdate() {
+        this._updateTitle(this.props.title);
+    }
+
+    _updateTitle = title => {
+        if (title) {
+            document.title = trimString(title);
+        }
+    };
+
+    render() {
+        if (this.props.children) {
+            return this.props.children;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This PR will add the <DocumentTitle /> wrappe that will update document.title with the value from props.title if available.

It can either be used as a wrapper or just as a component that will not render anything.

BTW, I couldn't get the Storybook to change the document.title with the component so I just removed the knobs and actions from this story, The component should work fine outside of Storybook.