### PR TITLE
Feature/7 Use classnames on all components

### DIFF
--- a/_stories/atoms/ButtonGroup/index.js
+++ b/_stories/atoms/ButtonGroup/index.js
@@ -11,7 +11,7 @@ const sizeOptions = {
     xs: 'xs',
     sm: 'sm',
     lg: 'lg',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/atoms/CircularThumbnail/index.js
+++ b/_stories/atoms/CircularThumbnail/index.js
@@ -9,11 +9,11 @@ const circularThumbnailSizeOptions = {
     sm: 'sm',
     lg: 'lg',
     xl: 'xl',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const circularThumbnailContexts = {
-    '': 'No Value',
+    'No Value': '',
     secondary: 'secondary',
     success: 'success',
     info: 'info',

--- a/_stories/atoms/LoadingDots/index.js
+++ b/_stories/atoms/LoadingDots/index.js
@@ -8,7 +8,7 @@ import LoadingDots from '../../../components/atoms/LoadingDots';
 const sizeOptions = {
     sm: 'sm',
     lg: 'lg',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/atoms/NumberCircle/index.js
+++ b/_stories/atoms/NumberCircle/index.js
@@ -6,7 +6,7 @@ import readme from './README.md';
 import NumberCircle from '../../../components/atoms/NumberCircle';
 
 const contextOptions = {
-    '': 'No Value',
+    'No Value': '',
     secondary: 'secondary',
     success: 'success',
     info: 'info',
@@ -20,7 +20,7 @@ const sizeOptions = {
     sm: 'sm',
     lg: 'lg',
     xl: 'xl',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/atoms/Select/index.js
+++ b/_stories/atoms/Select/index.js
@@ -28,14 +28,14 @@ const options = [
 ];
 
 const contextOptions = {
-    '': 'No Value',
+    'No Value': '',
     primary: 'primary',
     'no-border': 'no-border',
     dark: 'dark'
 };
 
 const sizeOptions = {
-    '': 'No Value',
+    'No Value': '',
     xs: 'xs',
     sm: 'sm',
     lg: 'lg'

--- a/_stories/atoms/Tag/index.js
+++ b/_stories/atoms/Tag/index.js
@@ -12,13 +12,13 @@ const contextOptions = {
     success: 'success',
     warning: 'warning',
     danger: 'danger',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const sizeOptions = {
     sm: 'sm',
     xs: 'xs',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/atoms/TextArea/index.js
+++ b/_stories/atoms/TextArea/index.js
@@ -7,14 +7,14 @@ import readme from './README.md';
 import TextArea from '../../../components/atoms/TextArea';
 
 const sizeOptions = {
-    '': 'No Value',
+    'No Value': '',
     xs: 'xs',
     sm: 'sm',
     lg: 'lg'
 };
 
 const resizeOptions = {
-    '': 'No Value',
+    'No Value': '',
     'resize-h': 'resize-h',
     'resize-v': 'resize-v',
     'no-resize': 'no-resize'

--- a/_stories/atoms/Tooltip/index.js
+++ b/_stories/atoms/Tooltip/index.js
@@ -14,7 +14,7 @@ const tooltipPositions = {
     'bottom-left': 'bottom-left',
     left: 'left',
     'top-left': 'top-left',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const tooltipContexts = {
@@ -22,19 +22,19 @@ const tooltipContexts = {
     warning: 'warning',
     info: 'info',
     danger: 'danger',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const tooltipSizeOptions = {
     lg: 'lg',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const tooltipVariationsOptions = {
     always: 'always',
     'no-animate': 'no-animate',
     bounce: 'bounce',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/layout/Column/index.js
+++ b/_stories/layout/Column/index.js
@@ -4,6 +4,7 @@ import { number } from '@storybook/addon-knobs';
 import readme from './README.md';
 import Column from '../../../components/layout/Column';
 import Row from '../../../components/layout/Row';
+import Card from '../../../components/molecules/Card';
 
 const component = () => (
     <Row>
@@ -13,7 +14,9 @@ const component = () => (
             md={number('Medium', 6)}
             lg={number('Large')}
             xl={number('Extra large')}>
-            column a
+            <Card option="underlined" className="-p-a-2">
+                column a
+            </Card>
         </Column>
         <Column
             xs={number('Extra Small')}
@@ -21,7 +24,9 @@ const component = () => (
             md={number('Medium', 6)}
             lg={number('Large')}
             xl={number('Extra large')}>
-            column b
+            <Card option="underlined" className="-p-a-2">
+                column b
+            </Card>
         </Column>
     </Row>
 );

--- a/_stories/layout/LayoutContainer/index.js
+++ b/_stories/layout/LayoutContainer/index.js
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 
 import readme from './README.md';
 import Column from '../../../components/layout/Column';
+import Card from '../../../components/molecules/Card';
 import LayoutContainer from '../../../components/layout/LayoutContainer';
 import Row from '../../../components/layout/Row';
 
@@ -14,9 +15,22 @@ const component = () => (
         onClick={action('layout_container_clicked')}
         className={text('Extra classes')}>
         <Row>
-            <Column md={4}>Example</Column>
-            <Column md={4}>Example</Column>
-            <Column md={4}>Example</Column>
+            <Column md={4}>
+                <Card option="underlined" className="-p-a-2">
+                    Example
+                </Card>
+            </Column>
+
+            <Column md={4}>
+                <Card option="underlined" className="-p-a-2">
+                    Example
+                </Card>
+            </Column>
+            <Column md={4}>
+                <Card option="underlined" className="-p-a-2">
+                    Example
+                </Card>
+            </Column>
         </Row>
     </LayoutContainer>
 );

--- a/_stories/molecules/Accordion/index.js
+++ b/_stories/molecules/Accordion/index.js
@@ -10,13 +10,13 @@ import AccordionItemContent from '../../../components/atoms/AccordionItemContent
 
 const sizeOptions = {
     sm: 'sm',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const contextOptions = {
     dark: 'dark',
     white: 'white',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/molecules/Card/index.js
+++ b/_stories/molecules/Card/index.js
@@ -11,7 +11,7 @@ const cardOptions = {
     white: 'white',
     underlined: 'underlined',
     'underlined-secondary': 'underlined-secondary',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const sizeOptions = {
@@ -20,7 +20,7 @@ const sizeOptions = {
     md: 'md',
     lg: 'lg',
     xl: 'xl',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/molecules/CardBlock/index.js
+++ b/_stories/molecules/CardBlock/index.js
@@ -9,7 +9,7 @@ import CardBlock from '../../../components/molecules/CardBlock';
 const options = {
     'divide-top': 'divide-top',
     'divide-bottom': 'divide-bottom',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/molecules/CardImage/index.js
+++ b/_stories/molecules/CardImage/index.js
@@ -9,11 +9,11 @@ import CardImage from '../../../components/molecules/CardImage';
 const options = {
     top: 'top',
     bottom: 'bottom',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const sizeOptions = {
-    '': 'No Value',
+    'No Value': '',
     xs: 'xs',
     sm: 'sm',
     md: 'md',

--- a/_stories/molecules/Checkbox/index.js
+++ b/_stories/molecules/Checkbox/index.js
@@ -10,7 +10,7 @@ import Checkbox from '../../../components/molecules/Checkbox';
 const sizeOptions = {
     sm: 'sm',
     xs: 'xs',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const component = () => (

--- a/_stories/molecules/FormGroup/index.js
+++ b/_stories/molecules/FormGroup/index.js
@@ -13,7 +13,7 @@ const contextOptions = {
     danger: 'danger',
     warning: 'warning',
     success: 'success',
-    '': 'No Value'
+    'No Value': ''
 };
 
 const selectOptions = [

--- a/_stories/molecules/MultiSelect/index.js
+++ b/_stories/molecules/MultiSelect/index.js
@@ -17,7 +17,7 @@ const options = Array(10)
 const sizeOptions = {
     sm: 'sm',
     xs: 'xs',
-    '': 'No Value'
+    'No Value': ''
 };
 
 class MultiSelectOptions extends Component {

--- a/_stories/molecules/Table/index.js
+++ b/_stories/molecules/Table/index.js
@@ -48,7 +48,7 @@ const sizeOptions = {
     sm: 'sm',
     lg: 'lg',
     xl: 'xl',
-    '': 'No Value'
+    'No Value': ''
 };
 
 // Column options

--- a/_stories/molecules/Well/index.js
+++ b/_stories/molecules/Well/index.js
@@ -7,7 +7,7 @@ import readme from './README.md';
 import Well from '../../../components/molecules/Well';
 
 const contextOptions = {
-    '': 'No Value',
+    'No Value': '',
     success: 'success',
     warning: 'warning',
     info: 'info',

--- a/components/atoms/AccordionItemContent.jsx
+++ b/components/atoms/AccordionItemContent.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 class AccordionItemContent extends Component {
     handleClick = e => {
@@ -9,16 +9,17 @@ class AccordionItemContent extends Component {
 
     render() {
         const { className, context, size, children, ...otherProps } = this.props;
-        const baseClass = 'gds-accordion__child-item';
-        const contextClass = context ? `${baseClass}--${context}` : '';
-        const classNames = trimString(`${baseClass} ${contextClass} ${className}`);
 
-        const titleBaseClass = 'gds-accordion__child-item-title';
-        const titleSizeClass = size ? `${titleBaseClass}--${size}` : '';
-        const titleClass = trimString(`${titleBaseClass} ${titleSizeClass}`);
+        const rootClass = cx('gds-accordion__child-item', className, {
+            [`gds-accordion__child-item--${context}`]: context
+        });
+
+        const titleClass = cx('gds-accordion__child-item-title', {
+            [`gds-accordion__child-item-title--${size}`]: size
+        });
 
         return (
-            <li className={classNames} onClick={this.handleClick} {...otherProps}>
+            <li className={rootClass} onClick={this.handleClick} {...otherProps}>
                 <h4 className={titleClass}>{children}</h4>
             </li>
         );
@@ -26,11 +27,6 @@ class AccordionItemContent extends Component {
 }
 
 AccordionItemContent.displayName = 'AccordionItemContent';
-
-AccordionItemContent.defaultProps = {
-    className: '',
-    context: ''
-};
 
 AccordionItemContent.propTypes = {
     children: PropTypes.node,

--- a/components/atoms/Badge.jsx
+++ b/components/atoms/Badge.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Badge = ({ text, context, empty, className, style }) => {
-    const baseClass = 'gds-badge',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        emptyClass = empty ? `${baseClass}--empty` : '';
+    const baseClass = 'gds-badge';
 
-    const classNames = trimString(`${baseClass} ${contextClass} ${emptyClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--empty`]: empty
+    });
 
-    return <span className={classNames}>{!empty && text}</span>;
+    return (
+        <span className={rootClass} style={style}>
+            {!empty && text}
+        </span>
+    );
 };
 
 Badge.displayName = 'Badge';
 
 Badge.defaultProps = {
     text: '',
-    context: '',
-    empty: false,
-    className: '',
-    style: {}
+    empty: false
 };
 
 Badge.propTypes = {

--- a/components/atoms/Button.jsx
+++ b/components/atoms/Button.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Button = ({
     context,
@@ -13,17 +13,16 @@ const Button = ({
     children,
     ...otherProps
 }) => {
-    const baseClass = 'gds-button',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '',
-        groupClass = group ? `${baseClass}-group__button` : '';
+    const baseClass = 'gds-button';
 
-    const classNames = trimString(
-        `${baseClass} ${contextClass} ${sizeClass} ${groupClass} ${className}`
-    );
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--${size}`]: size,
+        [`${baseClass}-group__button`]: group
+    });
 
     return (
-        <button className={classNames} type={type} style={style} onClick={onClick} {...otherProps}>
+        <button className={rootClass} type={type} style={style} onClick={onClick} {...otherProps}>
             {children}
         </button>
     );

--- a/components/atoms/ButtonGroup.jsx
+++ b/components/atoms/ButtonGroup.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const ButtonGroup = ({ size, responsive, className, style, children }) => {
-    const baseClass = 'gds-button-group',
-        sizeClass = size ? `${baseClass}--${size}` : '',
-        responsiveClass = responsive ? 'gds-button-group--responsive' : '';
+    const baseClass = 'gds-button-group';
 
-    const classNames = trimString(`${baseClass} ${responsiveClass} ${sizeClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${size}`]: size,
+        [`${baseClass}--responsive`]: responsive
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             {children}
         </div>
     );

--- a/components/atoms/CircularThumbnail.jsx
+++ b/components/atoms/CircularThumbnail.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const CircularThumbnail = ({ context, size, className, ...otherProps }) => {
-    const baseClass = 'gds-circular-thumbnail',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
+    const baseClass = 'gds-circular-thumbnail';
 
-    const classNames = trimString(`${baseClass} ${contextClass} ${sizeClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--${size}`]: size
+    });
 
-    return <img className={classNames} {...otherProps} />;
+    return <img className={rootClass} {...otherProps} />;
 };
 
 CircularThumbnail.displayName = 'CircularThumbnail';

--- a/components/atoms/FormGroupLabel.jsx
+++ b/components/atoms/FormGroupLabel.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const FormGroupLabel = ({ text, className, ...otherProps }) => (
-    <label className={`gds-form-group__label ${className}`} {...otherProps}>
+    <label className={cx('gds-form-group__label', className)} {...otherProps}>
         {text}
     </label>
 );
@@ -12,10 +13,6 @@ FormGroupLabel.displayName = 'FormGroupLabel';
 FormGroupLabel.propTypes = {
     text: PropTypes.string.isRequired,
     className: PropTypes.string
-};
-
-FormGroupLabel.defaultProps = {
-    className: ''
 };
 
 export default FormGroupLabel;

--- a/components/atoms/FormGroupTextHelp.jsx
+++ b/components/atoms/FormGroupTextHelp.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const FormGroupTextHelp = ({ text, className, ...otherProps }) => (
-    <small className={`gds-form-group__text-help ${className}`} {...otherProps}>
+    <small className={cx('gds-form-group__text-help', className)} {...otherProps}>
         {text}
     </small>
 );
@@ -12,10 +13,6 @@ FormGroupTextHelp.displayName = 'FormGroupTextHelp';
 FormGroupTextHelp.propTypes = {
     text: PropTypes.string.isRequired,
     className: PropTypes.string
-};
-
-FormGroupTextHelp.defaultProps = {
-    className: ''
 };
 
 export default FormGroupTextHelp;

--- a/components/atoms/LoadingDots.jsx
+++ b/components/atoms/LoadingDots.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
-const LoadingDots = ({ whiteDots = false, size, className, style }) => {
-    const baseClass = 'gds-loading__dot',
-        whiteDotsClass = whiteDots ? `${baseClass}--white` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
-
-    const classNames = trimString(`${baseClass} ${whiteDotsClass} ${sizeClass}`);
+const LoadingDots = ({ whiteDots, size, className, style }) => {
+    const baseClass = 'gds-loading__dot';
+    const dotClasses = cx(baseClass, {
+        [`${baseClass}--${size}`]: size,
+        [`${baseClass}--white`]: whiteDots
+    });
 
     return (
         <div style={style} className={className}>
             <div className="gds-loading">
-                <div className={classNames} />
+                <div className={dotClasses} />
             </div>
         </div>
     );

--- a/components/atoms/ModalBody.jsx
+++ b/components/atoms/ModalBody.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const ModalBody = ({ className, style, children }) => (
-    <div className={`gds-modal__body ${className}`} style={style}>
+    <div className={cx('gds-modal__body', className)} style={style}>
         {children}
     </div>
 );

--- a/components/atoms/ModalFooter.jsx
+++ b/components/atoms/ModalFooter.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const ModalFooter = ({ className, style, children }) => (
-    <div className={`gds-modal__footer -text-right ${className}`} style={style}>
+    <div className={cx('gds-modal__footer', '-text-right', className)} style={style}>
         {children}
     </div>
 );

--- a/components/atoms/ModalForm.jsx
+++ b/components/atoms/ModalForm.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const ModalForm = ({ className, children, ...otherProps }) => (
-    <form className={`gds-modal__form ${className}`} {...otherProps}>
+    <form className={cx('gds-modal__form', className)} {...otherProps}>
         {children}
     </form>
 );

--- a/components/atoms/ModalHeader.jsx
+++ b/components/atoms/ModalHeader.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const ModalHeader = ({ title, onClose, className, style }) => (
-    <div className={`gds-modal__header ${className}`} style={style}>
+    <div className={cx('gds-modal__header', className)} style={style}>
         {title && <h2 className="gds-modal__title gds-text--header-sm">{title}</h2>}
         {onClose && (
             <button onClick={onClose} type="button" className="gds-modal__close-button -z-9" />

--- a/components/atoms/NumberCircle.jsx
+++ b/components/atoms/NumberCircle.jsx
@@ -1,27 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const NumberCircle = ({ text, context, size, className, style }) => {
-    const baseClass = 'gds-number-circle',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
+    const baseClass = 'gds-number-circle';
 
-    const classNames = trimString(`${baseClass} ${contextClass} ${sizeClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <span className={classNames} style={style}>
+        <span className={rootClass} style={style}>
             {text}
         </span>
     );
 };
 
 NumberCircle.displayName = 'NumberCircle';
-
-NumberCircle.defaultProps = {
-    context: null,
-    style: {}
-};
 
 NumberCircle.propTypes = {
     text: PropTypes.string,

--- a/components/atoms/Select.jsx
+++ b/components/atoms/Select.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Select = ({ context, size, customValue, customName, options, className, ...otherProps }) => {
-    const baseClass = 'gds-form-group__select-input',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
+    const baseClass = 'gds-form-group__select-input';
 
-    const classNames = trimString(`${baseClass} ${contextClass} ${sizeClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <select className={classNames} {...otherProps}>
+        <select className={rootClass} {...otherProps}>
             {options.map(o => (
                 <option key={o[customValue]} value={o[customValue]}>
                     {o[customName]}

--- a/components/atoms/TextArea.jsx
+++ b/components/atoms/TextArea.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const TextArea = ({ className, resize, size, placeholder, style, ...otherProps }) => {
     const baseClass = 'gds-form-group__text-area-input';
-    const sizeClass = size ? `${baseClass}--${size}` : '';
-    const resizeClass = resize ? `${baseClass}--${resize}` : '';
-    const classNames = trimString(`${baseClass} ${sizeClass} ${resizeClass} ${className}`);
+
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${resize}`]: resize,
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <textarea placeholder={placeholder} style={style} className={classNames} {...otherProps} />
+        <textarea placeholder={placeholder} style={style} className={rootClass} {...otherProps} />
     );
 };
 

--- a/components/atoms/TextInput.jsx
+++ b/components/atoms/TextInput.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const TextInput = ({ className, type, size, ...otherProps }) => {
-    const sizeClass = size ? `gds-form-group__text-input--${size}` : '';
-    return (
-        <input
-            className={`gds-form-group__text-input ${sizeClass} ${className}`}
-            type={type}
-            {...otherProps}
-        />
-    );
+    const baseClass = 'gds-form-group__text-input';
+
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${size}`]: size
+    });
+
+    return <input className={rootClass} type={type} {...otherProps} />;
 };
 
 TextInput.displayName = 'TextInput';

--- a/components/atoms/Tooltip.jsx
+++ b/components/atoms/Tooltip.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Tooltip = ({
     text,
@@ -12,18 +12,17 @@ const Tooltip = ({
     children,
     ...otherProps
 }) => {
-    const baseClass = 'gds-tooltip',
-        positionClass = position ? `${baseClass}--${position}` : '',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '',
-        variationsClass = variations ? `${baseClass}--${variations}` : '';
+    const baseClass = 'gds-tooltip';
 
-    const classNames = trimString(
-        `${positionClass} ${contextClass} ${sizeClass} ${variationsClass} ${className}`
-    );
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${size}`]: size,
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--${variations}`]: variations,
+        [`${baseClass}--${position}`]: position
+    });
 
     return (
-        <div className={classNames} data-tooltip={text} {...otherProps}>
+        <div className={rootClass} data-tooltip={text} {...otherProps}>
             {children}
         </div>
     );

--- a/components/atoms/Trend.jsx
+++ b/components/atoms/Trend.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Trend = ({ context, className, style, value, unit }) => {
-    const classNames = trimString(`gds-card__trend gds-card__trend--${context} ${className}`);
+    const baseClass = 'gds-card__trend';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             {value}
             {unit}
         </div>
@@ -17,8 +20,6 @@ Trend.displayName = 'Trend';
 
 Trend.defaultProps = {
     context: 'up',
-    className: '',
-    style: {},
     unit: '%'
 };
 

--- a/components/layout/Column.jsx
+++ b/components/layout/Column.jsx
@@ -2,15 +2,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Column = options => {
-    const { xs, sm, md, lg, xl, className, children, ...props } = options;
+const Column = ({ xs, sm, md, lg, xl, className, children, ...props }) => {
     const sizes = { xs, sm, md, lg, xl };
+
     const classList = Object.keys(sizes)
         .reduce((list, breakpoint) => {
             const size = sizes[breakpoint];
             return list.concat(size ? `gds-layout__column--${breakpoint}-${size}` : []);
         }, [])
         .concat(className || []);
+
     return (
         <div className={classList.join(' ')} {...props}>
             {children}
@@ -26,6 +27,7 @@ Column.defaultProps = {
 
 Column.propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
     xs: PropTypes.number,
     sm: PropTypes.number,
     md: PropTypes.number,

--- a/components/layout/LayoutContainer.jsx
+++ b/components/layout/LayoutContainer.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const LayoutContainer = ({ className, fullWidth, children, ...props }) => {
-    const baseClass = fullWidth ? 'gds-layout__container--full-width' : 'gds-layout__container';
-    const classNames = trimString(`${baseClass} ${className}`);
+    const baseClass = 'gds-layout__container';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--full-width`]: fullWidth
+    });
+
     return (
-        <div className={classNames} {...props}>
+        <div className={rootClass} {...props}>
             {children}
         </div>
     );
@@ -15,7 +18,6 @@ const LayoutContainer = ({ className, fullWidth, children, ...props }) => {
 LayoutContainer.displayName = 'LayoutContainer';
 
 LayoutContainer.defaultProps = {
-    className: '',
     fullWidth: false
 };
 

--- a/components/layout/Row.jsx
+++ b/components/layout/Row.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const Row = ({ className, children, ...props }) => (
-    <div className={`gds-layout__row ${className}`} {...props}>
+    <div className={cx('gds-layout__row', className)} {...props}>
         {children}
     </div>
 );
 
 Row.displayName = 'Row';
-
-Row.defaultProps = {
-    className: ''
-};
 
 Row.propTypes = {
     children: PropTypes.node,

--- a/components/molecules/BreadcrumbsWrapper.jsx
+++ b/components/molecules/BreadcrumbsWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const BreadcrumbsWrapper = ({ children, ...props }) => (

--- a/components/molecules/Card.jsx
+++ b/components/molecules/Card.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Card = ({ option, size, className, style, children }) => {
-    const baseClass = 'gds-card',
-        optionClass = option ? `${baseClass}--${option}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
-
-    const classNames = trimString(`${baseClass} ${optionClass} ${sizeClass} ${className}`);
+    const baseClass = 'gds-card';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${option}`]: option,
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             {children}
         </div>
     );

--- a/components/molecules/CardBlock.jsx
+++ b/components/molecules/CardBlock.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
 
 const CardBlock = ({ option, className, style, children }) => {
-    const baseClass = 'gds-card__block',
-        optionClass = option ? `${baseClass}--${option}` : '';
-
-    const classNames = `${baseClass} ${optionClass} ${className}`;
+    const baseClass = 'gds-card__block';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${option}`]: option
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             {children}
         </div>
     );

--- a/components/molecules/CardImage.jsx
+++ b/components/molecules/CardImage.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const CardImage = ({ url, option, size, className, style }) => {
-    const baseClass = 'gds-card__img-container',
-        optionClass = option ? `${baseClass}--${option}` : '',
-        sizeClass = size ? `${baseClass}--${size}` : '';
-
-    const classNames = trimString(`${baseClass} ${optionClass} ${sizeClass} ${className}`);
+    const baseClass = 'gds-card__img-container';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${option}`]: option,
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             <img className="gds-card__img" src={url} />
             <div className="gds-card__img-helper" />
         </div>

--- a/components/molecules/Checkbox.jsx
+++ b/components/molecules/Checkbox.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Checkbox = ({ label, size, style, className, ...otherProps }) => {
     const baseClass = 'gds-form-group__checkbox';
-    const sizeClass = size ? `${baseClass}--${size}` : '';
-    const classNames = trimString(`${baseClass} ${sizeClass} ${className}`);
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             <label className="gds-form-group__checkbox-label">
                 <input className="gds-form-group__checkbox-input" type="checkbox" {...otherProps} />
                 <span className="gds-form-group__checkbox-indicator" />

--- a/components/molecules/Divider.jsx
+++ b/components/molecules/Divider.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Divider = ({
     label,
@@ -11,17 +11,18 @@ const Divider = ({
     className,
     style
 }) => {
-    const baseClass = 'gds-divider',
-        centeredClass = centered ? `${baseClass}--centered` : '',
-        collapsibleClass = collapsible ? 'gds-button--collapsible' : '',
-        arrowClasses = open
-            ? `${baseClass}__arrow`
-            : `${baseClass}__arrow ${baseClass}__arrow--collapse`;
+    const baseClass = 'gds-divider';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${centered}`]: centered,
+        [`${baseClass}--${collapsible}`]: collapsible
+    });
 
-    const classNames = trimString(`${baseClass} ${centeredClass} ${collapsibleClass} ${className}`);
+    const arrowClasses = cx(`${baseClass}__arrow`, {
+        [`${baseClass}__arrow--collapse`]: !open
+    });
 
     return (
-        <div className={classNames} style={style} onClick={callback}>
+        <div className={rootClass} style={style} onClick={callback}>
             {centered && <span className="gds-divider__line" />}
             <span className="gds-divider__label gds-form-group__label">{label}</span>
             <span className="gds-divider__line" />
@@ -38,7 +39,6 @@ Divider.defaultProps = {
     collapsible: false,
     open: null,
     callback: null,
-    className: '',
     style: {}
 };
 

--- a/components/molecules/FormGroup.jsx
+++ b/components/molecules/FormGroup.jsx
@@ -1,32 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const FormGroup = ({ isInline, isDisabled, context, className, children, ...otherProps }) => {
     const baseClass = 'gds-form-group';
-    const inlineClass = isInline ? `${baseClass}--inline` : '';
-    const disabledClass = isDisabled ? `${baseClass}--disabled` : '';
-    const contextClass = context ? `${baseClass}--${context}` : '';
 
-    const classNames = trimString(
-        `${baseClass} ${inlineClass} ${contextClass} ${disabledClass} ${className}`
-    );
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context,
+        [`${baseClass}--disabled`]: isDisabled,
+        [`${baseClass}--inline`]: isInline
+    });
 
     return (
-        <div className={classNames} {...otherProps}>
+        <div className={rootClass} {...otherProps}>
             {children}
         </div>
     );
 };
 
 FormGroup.displayName = 'FormGroup';
-
-FormGroup.defaultProps = {
-    isInline: false,
-    isDisabled: false,
-    context: '',
-    className: ''
-};
 
 FormGroup.propTypes = {
     isInline: PropTypes.bool,

--- a/components/molecules/Modal.jsx
+++ b/components/molecules/Modal.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
+import cx from 'classnames';
 
 const Modal = ({ onClose, isOpen, className, overlayClassName, style, md, children }) => (
     <ReactModal
-        className={`gds-modal gds-layout__column--md-${md} ${className} -float-none`}
-        overlayClassName={`gds-modal__overlay gds-modal--shown ${overlayClassName}`}
+        className={cx('gds-modal', className, '-float-none', {
+            [`gds-layout__column--md-${md}`]: md
+        })}
+        overlayClassName={cx('gds-modal__overlay', 'gds-modal--shown', overlayClassName)}
         contentLabel="default"
         onRequestClose={onClose}
         isOpen={isOpen}
@@ -19,9 +22,6 @@ Modal.displayName = 'Modal';
 
 Modal.defaultProps = {
     isOpen: false,
-    className: '',
-    overlayClassName: '',
-    style: {},
     md: '12'
 };
 

--- a/components/molecules/Toggle.jsx
+++ b/components/molecules/Toggle.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Toggle = ({ type, size, label, style, className, ...otherProps }) => {
     const baseClass = 'gds-form-group__toggleswitch';
-    const sizeClass = size ? `${baseClass}--${size}` : '';
-    const classNames = trimString(`${baseClass} ${sizeClass} ${className}`);
+
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${size}`]: size
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             <label className="gds-form-group__toggleswitch-label">
                 <input className="gds-form-group__toggleswitch-input" type={type} {...otherProps} />
                 <span className="gds-form-group__toggleswitch-indicator" />
@@ -22,10 +24,7 @@ Toggle.displayName = 'Toggle';
 
 Toggle.defaultProps = {
     type: 'checkbox',
-    size: '',
-    label: '',
-    className: '',
-    style: {}
+    label: ''
 };
 
 Toggle.propTypes = {

--- a/components/molecules/Well.jsx
+++ b/components/molecules/Well.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import trimString from '../utils/trimString';
+import cx from 'classnames';
 
 const Well = ({ text, context, button, callback, className, style }) => {
-    const baseClass = 'gds-well',
-        contextClass = context ? `${baseClass}--${context}` : '',
-        buttonClass = context
-            ? `gds-well__button gds-well__button--${context}`
-            : 'gds-well__button';
+    const baseClass = 'gds-well';
+    const rootClass = cx(baseClass, className, {
+        [`${baseClass}--${context}`]: context
+    });
 
-    const classNames = trimString(`${baseClass} ${contextClass} ${className}`);
+    const buttonClass = cx('gds-well__button', {
+        [`gds-well__button--${context}`]: context
+    });
 
     return (
-        <div className={classNames} style={style}>
+        <div className={rootClass} style={style}>
             <p className="gds-well__text">{text}</p>
             {button && callback && <button className={buttonClass} onClick={callback} />}
         </div>

--- a/components/utils/optionalSelect.js
+++ b/components/utils/optionalSelect.js
@@ -16,7 +16,7 @@ so the prop isn't included in the component:
 const sizeOptions = {
     sm: 'sm',
     xs: 'xs',
-    '': 'No Value'
+    'No Value': ''
 };
 
 <Foo size={optionalSelect('Size', sizeOptions)} />

--- a/components/utils/trimString.js
+++ b/components/utils/trimString.js
@@ -1,3 +1,0 @@
-const trimString = string => string.replace(/\s+/g, ' ').trim();
-
-export default trimString;


### PR DESCRIPTION
Address #7 

## Changes

- Use `classnames` lib where applicable
- Fix some warnings related to the updated `select` knob API
  - `'': 'No Value',` => `'No Value': '',`
- Updated a couple stories to make them look better