### PR TITLE
Feature/jest snapshot tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,19 @@
         ],
         "stage-0",
         "react"
-    ]
+    ],
+    "env": {
+        "test": {
+            "presets": [
+                [
+                    "env",
+                    {
+                        "modules": "commonjs"
+                    }
+                ],
+                "stage-0",
+                "react"
+            ]
+        }
+    }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "env": {
         "es6": true,
         "browser": true,
-        "node": true
+        "node": true,
+        "jest": true
     },
     "parser": "babel-eslint",
     "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ dist/
 dist-es/
 gumgum-common-js-*.tgz
 gumdrops-*.tgz
+yarn-error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "10"
+cache:
+  directories:
+    - "node_modules"
+script: yarn test
+branches:
+  only:
+  - /.*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,22 @@ ButtonGroup.propTypes = {
 
 **IMPORTANT**: Please wait for approvals, and when your PR has been approved, **please continue to follow the guidelines on [GITWORKFLOW.md](GITWORKFLOW.md) when rebasing and merging**.
 
+##### Running Tests
+
+Gumdrops uses [Jest](https://jestjs.io/docs/en/getting-started) and [Enzyme](http://airbnb.io/enzyme/) to test components. All tests can be found in `/_tests` in their corresponding folders.
+
+To run tests use
+
+```
+yarn test
+```
+
+or to run Jest in interactive watch mode
+
+```
+yarn test:watch
+```
+
 #### Local testing
 
 This library can be installed into a different project for local testing/development:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains reusable JavaScript React components that you can import into your project.
 
-[![npm version](https://badge.fury.io/js/gumdrops.svg)](https://badge.fury.io/js/gumdrops) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![npm version](https://badge.fury.io/js/gumdrops.svg)](https://badge.fury.io/js/gumdrops) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Build Status](https://travis-ci.org/gumgum/gumdrops.svg?branch=master)](https://travis-ci.org/gumgum/gumdrops)
 
 ## Prerequisites
 

--- a/_tests/atoms/AccordionItem.test.js
+++ b/_tests/atoms/AccordionItem.test.js
@@ -1,0 +1,20 @@
+/* globals mount */
+import React from 'react';
+import AccordionItem from '../../components/atoms/AccordionItem';
+
+describe('Expect <AccordionItem>', () => {
+    it('to render', () => {
+        const props = {
+            className: 'foo',
+            label: 'Foo!',
+            size: 'xs',
+            context: 'danger'
+        };
+        const wrapper = mount(
+            <AccordionItem {...props}>
+                <div>foo</div>
+            </AccordionItem>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/AccordionItemContent.test.js
+++ b/_tests/atoms/AccordionItemContent.test.js
@@ -1,0 +1,19 @@
+/* globals mount */
+import React from 'react';
+import AccordionItemContent from '../../components/atoms/AccordionItemContent';
+
+describe('Expect <AccordionItemContent>', () => {
+    it('to render', () => {
+        const props = {
+            className: 'foo',
+            size: 'xs',
+            context: 'danger'
+        };
+        const wrapper = mount(
+            <AccordionItemContent {...props}>
+                <div>foo</div>
+            </AccordionItemContent>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/Badge.test.js
+++ b/_tests/atoms/Badge.test.js
@@ -1,0 +1,34 @@
+/* globals mount */
+import React from 'react';
+import Badge from '../../components/atoms/Badge';
+
+describe('Expect <Badge>', () => {
+    it('to render', () => {
+        const props = {
+            text: 'This is text',
+            context: 'inverse',
+            className: 'foo-class',
+            style: {
+                width: '1000px'
+            }
+        };
+
+        const wrapper = mount(<Badge {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render properly with empty', () => {
+        const props = {
+            text: 'Ignored text',
+            context: 'inverse',
+            className: 'foo-class',
+            empty: true,
+            style: {
+                width: '1000px'
+            }
+        };
+
+        const wrapper = mount(<Badge {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/Button.test.js
+++ b/_tests/atoms/Button.test.js
@@ -1,0 +1,32 @@
+/* globals mount */
+import React from 'react';
+import Button from '../../components/atoms/Button';
+
+const defaultProps = {
+    group: false,
+    size: 'sm',
+    onClick: () => {},
+    text: 'This is text',
+    context: 'danger',
+    className: 'foo-class',
+    style: {
+        width: '1000px'
+    },
+    onBlur: () => {}
+};
+
+describe('Expect <Button>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Button {...defaultProps}>My Cool Button</Button>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to renders as a group button', () => {
+        const props = {
+            ...defaultProps,
+            group: true
+        };
+        const wrapper = mount(<Button {...props}>My Cool Button</Button>);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/CircularThumbnail.test.js
+++ b/_tests/atoms/CircularThumbnail.test.js
@@ -1,0 +1,16 @@
+/* globals mount */
+import React from 'react';
+import CircularThumbnail from '../../components/atoms/CircularThumbnail';
+
+const defaultProps = {
+    size: 'sm',
+    context: 'danger',
+    className: 'foo-class'
+};
+
+describe('Expect <CircularThumbnail>', () => {
+    it('to render', () => {
+        const wrapper = mount(<CircularThumbnail {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/FormGroupLabel.test.js
+++ b/_tests/atoms/FormGroupLabel.test.js
@@ -1,0 +1,15 @@
+/* globals mount */
+import React from 'react';
+import FormGroupLabel from '../../components/atoms/FormGroupLabel';
+
+const defaultProps = {
+    text: 'Label Baby Jr',
+    className: 'my-classy-class'
+};
+
+describe('Expect <FormGroupLabel>', () => {
+    it('to render', () => {
+        const wrapper = mount(<FormGroupLabel {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/FormGroupTextHelp.test.js
+++ b/_tests/atoms/FormGroupTextHelp.test.js
@@ -1,0 +1,15 @@
+/* globals mount */
+import React from 'react';
+import FormGroupTextHelp from '../../components/atoms/FormGroupTextHelp';
+
+const defaultProps = {
+    text: 'Oh no, errors!',
+    className: 'much-error'
+};
+
+describe('Expect <FormGroupTextHelp>', () => {
+    it('to render', () => {
+        const wrapper = mount(<FormGroupTextHelp {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/LoadingDots.test.js
+++ b/_tests/atoms/LoadingDots.test.js
@@ -1,0 +1,26 @@
+/* globals mount */
+import React from 'react';
+import LoadingDots from '../../components/atoms/LoadingDots';
+
+const defaultProps = {
+    className: 'cool-class',
+    size: 'lg',
+    style: { width: '100px' }
+};
+
+describe('Expect <LoadingDots>', () => {
+    it('to render', () => {
+        const wrapper = mount(<LoadingDots {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render as white', () => {
+        const props = {
+            ...defaultProps,
+            isWhite: true
+        };
+
+        const wrapper = mount(<LoadingDots {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/ModalBody.test.js
+++ b/_tests/atoms/ModalBody.test.js
@@ -1,0 +1,19 @@
+/* globals mount */
+import React from 'react';
+import ModalBody from '../../components/atoms/ModalBody';
+
+const defaultProps = {
+    className: 'modal-class',
+    style: { width: '100px' }
+};
+
+describe('Expect <ModalBody>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <ModalBody {...defaultProps}>
+                <div>My modal content</div>
+            </ModalBody>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/ModalFooter.test.js
+++ b/_tests/atoms/ModalFooter.test.js
@@ -1,0 +1,19 @@
+/* globals mount */
+import React from 'react';
+import ModalFooter from '../../components/atoms/ModalFooter';
+
+const defaultProps = {
+    className: 'modal-class',
+    style: { width: '100px' }
+};
+
+describe('Expect <ModalFooter>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <ModalFooter {...defaultProps}>
+                <div>My modal content</div>
+            </ModalFooter>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/ModalForm.test.js
+++ b/_tests/atoms/ModalForm.test.js
@@ -1,0 +1,19 @@
+/* globals mount */
+import React from 'react';
+import ModalForm from '../../components/atoms/ModalForm';
+
+const defaultProps = {
+    className: 'modal-class',
+    style: { width: '100px' }
+};
+
+describe('Expect <ModalForm>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <ModalForm {...defaultProps}>
+                <div>My form content</div>
+            </ModalForm>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/NumberCircle.test.js
+++ b/_tests/atoms/NumberCircle.test.js
@@ -1,0 +1,18 @@
+/* globals mount */
+import React from 'react';
+import NumberCircle from '../../components/atoms/NumberCircle';
+
+const defaultProps = {
+    className: 'modal-class',
+    context: 'success',
+    size: 'lg',
+    text: '100',
+    style: { width: '100px' }
+};
+
+describe('Expect <NumberCircle>', () => {
+    it('to render', () => {
+        const wrapper = mount(<NumberCircle {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/Select.test.js
+++ b/_tests/atoms/Select.test.js
@@ -1,0 +1,27 @@
+/* globals mount */
+import React from 'react';
+import Select from '../../components/atoms/Select';
+
+const defaultProps = {
+    className: 'modal-class',
+    context: 'success',
+    size: 'lg',
+    text: '100',
+    options: [
+        {
+            value: 'foo',
+            name: 'Foot'
+        },
+        {
+            value: 'woo',
+            name: 'Woot'
+        }
+    ]
+};
+
+describe('Expect <Select>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Select {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/Tag.test.js
+++ b/_tests/atoms/Tag.test.js
@@ -1,0 +1,34 @@
+/* globals mount */
+import React from 'react';
+import Tag from '../../components/atoms/Tag';
+
+const defaultProps = {
+    context: 'primary',
+    className: 'custom-class',
+    onClick: () => {},
+    onOptionClick: () => {},
+    hasOption: true,
+    optionIcon: 'bt-times',
+    optionLabel: 'Remove me',
+    size: 'sm',
+    style: { wdith: '100%' },
+    text: 'Cool Tagz'
+};
+
+describe('Expect <Tag>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Tag {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render without option', () => {
+        const props = {
+            ...defaultProps,
+            hasOption: false,
+            onOptionClick: undefined,
+            optionIcon: undefined
+        };
+        const wrapper = mount(<Tag {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/atoms/__snapshots__/AccordionItem.test.js.snap
+++ b/_tests/atoms/__snapshots__/AccordionItem.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <AccordionItem> to render 1`] = `
+<AccordionItem
+  className="foo"
+  context="danger"
+  label="Foo!"
+  size="xs"
+>
+  <li
+    aria-controls="AccordionItem-region-QWNjb3JkaW9uSXRlbQ==0"
+    aria-expanded={false}
+    aria-pressed={false}
+    className="gds-accordion__item foo gds-accordion__item--danger"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <h4
+      className="gds-accordion__item-title gds-accordion__item-title--xs"
+      id="AccordionItem-label-QWNjb3JkaW9uSXRlbQ==0"
+    >
+      Foo!
+    </h4>
+    <span
+      className="gds-accordion__item-icon gds-accordion__item-icon--xs"
+    />
+    <ul
+      aria-hidden={true}
+      aria-labelledby="AccordionItem-label-QWNjb3JkaW9uSXRlbQ==0"
+      className="gds-accordion__child-items gds-accordion__child-items--xs"
+      id="AccordionItem-region-QWNjb3JkaW9uSXRlbQ==0"
+      role="region"
+    >
+      <div
+        context="danger"
+        key=".0"
+        size="xs"
+      >
+        foo
+      </div>
+    </ul>
+  </li>
+</AccordionItem>
+`;

--- a/_tests/atoms/__snapshots__/AccordionItemContent.test.js.snap
+++ b/_tests/atoms/__snapshots__/AccordionItemContent.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <AccordionItemContent> to render 1`] = `
+<AccordionItemContent
+  className="foo"
+  context="danger"
+  size="xs"
+>
+  <li
+    className="gds-accordion__child-item foo gds-accordion__child-item--danger"
+    onClick={[Function]}
+  >
+    <h4
+      className="gds-accordion__child-item-title gds-accordion__child-item-title--xs"
+    >
+      <div>
+        foo
+      </div>
+    </h4>
+  </li>
+</AccordionItemContent>
+`;

--- a/_tests/atoms/__snapshots__/Badge.test.js.snap
+++ b/_tests/atoms/__snapshots__/Badge.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Badge> to render 1`] = `
+<Badge
+  className="foo-class"
+  context="inverse"
+  empty={false}
+  style={
+    Object {
+      "width": "1000px",
+    }
+  }
+  text="This is text"
+>
+  <span
+    className="gds-badge foo-class gds-badge--inverse"
+    style={
+      Object {
+        "width": "1000px",
+      }
+    }
+  >
+    This is text
+  </span>
+</Badge>
+`;
+
+exports[`Expect <Badge> to render properly with empty 1`] = `
+<Badge
+  className="foo-class"
+  context="inverse"
+  empty={true}
+  style={
+    Object {
+      "width": "1000px",
+    }
+  }
+  text="Ignored text"
+>
+  <span
+    className="gds-badge foo-class gds-badge--inverse gds-badge--empty"
+    style={
+      Object {
+        "width": "1000px",
+      }
+    }
+  />
+</Badge>
+`;

--- a/_tests/atoms/__snapshots__/Button.test.js.snap
+++ b/_tests/atoms/__snapshots__/Button.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Button> to render 1`] = `
+<Button
+  className="foo-class"
+  context="danger"
+  group={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  size="sm"
+  style={
+    Object {
+      "width": "1000px",
+    }
+  }
+  text="This is text"
+  type="button"
+>
+  <button
+    className="gds-button foo-class gds-button--danger gds-button--sm"
+    onBlur={[Function]}
+    onClick={[Function]}
+    style={
+      Object {
+        "width": "1000px",
+      }
+    }
+    text="This is text"
+    type="button"
+  >
+    My Cool Button
+  </button>
+</Button>
+`;
+
+exports[`Expect <Button> to renders as a group button 1`] = `
+<Button
+  className="foo-class"
+  context="danger"
+  group={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  size="sm"
+  style={
+    Object {
+      "width": "1000px",
+    }
+  }
+  text="This is text"
+  type="button"
+>
+  <button
+    className="gds-button foo-class gds-button--danger gds-button--sm gds-button-group__button"
+    onBlur={[Function]}
+    onClick={[Function]}
+    style={
+      Object {
+        "width": "1000px",
+      }
+    }
+    text="This is text"
+    type="button"
+  >
+    My Cool Button
+  </button>
+</Button>
+`;

--- a/_tests/atoms/__snapshots__/CircularThumbnail.test.js.snap
+++ b/_tests/atoms/__snapshots__/CircularThumbnail.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <CircularThumbnail> to render 1`] = `
+<CircularThumbnail
+  className="foo-class"
+  context="danger"
+  size="sm"
+>
+  <img
+    className="gds-circular-thumbnail foo-class gds-circular-thumbnail--danger gds-circular-thumbnail--sm"
+  />
+</CircularThumbnail>
+`;

--- a/_tests/atoms/__snapshots__/FormGroupLabel.test.js.snap
+++ b/_tests/atoms/__snapshots__/FormGroupLabel.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <FormGroupLabel> to render 1`] = `
+<FormGroupLabel
+  className="my-classy-class"
+  text="Label Baby Jr"
+>
+  <label
+    className="gds-form-group__label my-classy-class"
+  >
+    Label Baby Jr
+  </label>
+</FormGroupLabel>
+`;

--- a/_tests/atoms/__snapshots__/FormGroupTextHelp.test.js.snap
+++ b/_tests/atoms/__snapshots__/FormGroupTextHelp.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <FormGroupTextHelp> to render 1`] = `
+<FormGroupTextHelp
+  className="much-error"
+  text="Oh no, errors!"
+>
+  <small
+    className="gds-form-group__text-help much-error"
+  >
+    Oh no, errors!
+  </small>
+</FormGroupTextHelp>
+`;

--- a/_tests/atoms/__snapshots__/LoadingDots.test.js.snap
+++ b/_tests/atoms/__snapshots__/LoadingDots.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <LoadingDots> to render 1`] = `
+<LoadingDots
+  className="cool-class"
+  size="lg"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+  whiteDots={false}
+>
+  <div
+    className="cool-class"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    <div
+      className="gds-loading"
+    >
+      <div
+        className="gds-loading__dot gds-loading__dot--lg"
+      />
+    </div>
+  </div>
+</LoadingDots>
+`;
+
+exports[`Expect <LoadingDots> to render as white 1`] = `
+<LoadingDots
+  className="cool-class"
+  isWhite={true}
+  size="lg"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+  whiteDots={false}
+>
+  <div
+    className="cool-class"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    <div
+      className="gds-loading"
+    >
+      <div
+        className="gds-loading__dot gds-loading__dot--lg"
+      />
+    </div>
+  </div>
+</LoadingDots>
+`;

--- a/_tests/atoms/__snapshots__/ModalBody.test.js.snap
+++ b/_tests/atoms/__snapshots__/ModalBody.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <ModalBody> to render 1`] = `
+<ModalBody
+  className="modal-class"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+>
+  <div
+    className="gds-modal__body modal-class"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    <div>
+      My modal content
+    </div>
+  </div>
+</ModalBody>
+`;

--- a/_tests/atoms/__snapshots__/ModalFooter.test.js.snap
+++ b/_tests/atoms/__snapshots__/ModalFooter.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <ModalFooter> to render 1`] = `
+<ModalFooter
+  className="modal-class"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+>
+  <div
+    className="gds-modal__footer -text-right modal-class"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    <div>
+      My modal content
+    </div>
+  </div>
+</ModalFooter>
+`;

--- a/_tests/atoms/__snapshots__/ModalForm.test.js.snap
+++ b/_tests/atoms/__snapshots__/ModalForm.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <ModalForm> to render 1`] = `
+<ModalForm
+  className="modal-class"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+>
+  <form
+    className="gds-modal__form modal-class"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    <div>
+      My form content
+    </div>
+  </form>
+</ModalForm>
+`;

--- a/_tests/atoms/__snapshots__/NumberCircle.test.js.snap
+++ b/_tests/atoms/__snapshots__/NumberCircle.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <NumberCircle> to render 1`] = `
+<NumberCircle
+  className="modal-class"
+  context="success"
+  size="lg"
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+  text="100"
+>
+  <span
+    className="gds-number-circle modal-class gds-number-circle--success gds-number-circle--lg"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+  >
+    100
+  </span>
+</NumberCircle>
+`;

--- a/_tests/atoms/__snapshots__/Select.test.js.snap
+++ b/_tests/atoms/__snapshots__/Select.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Select> to render 1`] = `
+<Select
+  className="modal-class"
+  context="success"
+  customName="name"
+  customValue="value"
+  options={
+    Array [
+      Object {
+        "name": "Foot",
+        "value": "foo",
+      },
+      Object {
+        "name": "Woot",
+        "value": "woo",
+      },
+    ]
+  }
+  size="lg"
+  text="100"
+>
+  <select
+    className="gds-form-group__select-input modal-class gds-form-group__select-input--success gds-form-group__select-input--lg"
+    text="100"
+  >
+    <option
+      key="foo"
+      value="foo"
+    >
+      Foot
+    </option>
+    <option
+      key="woo"
+      value="woo"
+    >
+      Woot
+    </option>
+  </select>
+</Select>
+`;

--- a/_tests/atoms/__snapshots__/Tag.test.js.snap
+++ b/_tests/atoms/__snapshots__/Tag.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Tag> to render 1`] = `
+<Tag
+  className="custom-class"
+  context="primary"
+  hasOption={true}
+  onClick={[Function]}
+  onOptionClick={[Function]}
+  optionIcon="bt-times"
+  optionLabel="Remove me"
+  size="sm"
+  style={
+    Object {
+      "wdith": "100%",
+    }
+  }
+  text="Cool Tagz"
+>
+  <div
+    className="gds-tag custom-class gds-tag--primary gds-tag--with-button gds-tag--with-button--sm gds-tag--sm"
+    onClick={[Function]}
+    style={
+      Object {
+        "wdith": "100%",
+      }
+    }
+  >
+    Cool Tagz
+    <button
+      aria-label="Remove me"
+      className="gds-tag__option gds-tag__option--primary gds-tag__option--sm"
+      onClick={[Function]}
+    >
+      <i
+        className="btl bt-fw bt-times"
+      />
+    </button>
+  </div>
+</Tag>
+`;
+
+exports[`Expect <Tag> to render without option 1`] = `
+<Tag
+  className="custom-class"
+  context="primary"
+  hasOption={false}
+  onClick={[Function]}
+  optionIcon="bt-times"
+  optionLabel="Remove me"
+  size="sm"
+  style={
+    Object {
+      "wdith": "100%",
+    }
+  }
+  text="Cool Tagz"
+>
+  <div
+    className="gds-tag custom-class gds-tag--primary gds-tag--sm"
+    onClick={[Function]}
+    style={
+      Object {
+        "wdith": "100%",
+      }
+    }
+  >
+    Cool Tagz
+  </div>
+</Tag>
+`;

--- a/_tests/jestSetup.js
+++ b/_tests/jestSetup.js
@@ -1,0 +1,10 @@
+import Enzyme, { shallow, render, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+// React 16 Enzyme adapter
+Enzyme.configure({ adapter: new Adapter() });
+
+// Make Enzyme functions available in all test files without importing
+global.shallow = shallow;
+global.render = render;
+global.mount = mount;

--- a/_tests/layout/Column.test.js
+++ b/_tests/layout/Column.test.js
@@ -1,0 +1,22 @@
+/* globals mount */
+import React from 'react';
+import Column from '../../components/layout/Column';
+
+describe('Expect <Column>', () => {
+    it('to render', () => {
+        const props = {
+            xs: 12,
+            sm: 6,
+            md: 4,
+            lg: 3,
+            xl: 2
+        };
+
+        const wrapper = mount(
+            <Column {...props}>
+                <div>Content</div>
+            </Column>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/layout/LayoutContainer.test.js
+++ b/_tests/layout/LayoutContainer.test.js
@@ -1,0 +1,30 @@
+/* globals mount */
+import React from 'react';
+import LayoutContainer from '../../components/layout/LayoutContainer';
+
+describe('Expect <LayoutContainer>', () => {
+    it('to render', () => {
+        const props = {
+            className: 'cool-stuff'
+        };
+        const wrapper = mount(
+            <LayoutContainer {...props}>
+                <div>Content</div>
+            </LayoutContainer>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render as full width', () => {
+        const props = {
+            className: 'cool-stuff',
+            fullWidth: true
+        };
+        const wrapper = mount(
+            <LayoutContainer {...props}>
+                <div>Content</div>
+            </LayoutContainer>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/layout/Row.test.js
+++ b/_tests/layout/Row.test.js
@@ -1,0 +1,17 @@
+/* globals mount */
+import React from 'react';
+import Row from '../../components/layout/Row';
+
+describe('Expect <Row>', () => {
+    it('to render', () => {
+        const props = {
+            className: 'cool-stuff'
+        };
+        const wrapper = mount(
+            <Row {...props}>
+                <div>Content</div>
+            </Row>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/layout/__snapshots__/Column.test.js.snap
+++ b/_tests/layout/__snapshots__/Column.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Column> to render 1`] = `
+<Column
+  lg={3}
+  md={4}
+  sm={6}
+  xl={2}
+  xs={12}
+>
+  <div
+    className="gds-layout__column--xs-12 gds-layout__column--sm-6 gds-layout__column--md-4 gds-layout__column--lg-3 gds-layout__column--xl-2"
+  >
+    <div>
+      Content
+    </div>
+  </div>
+</Column>
+`;

--- a/_tests/layout/__snapshots__/LayoutContainer.test.js.snap
+++ b/_tests/layout/__snapshots__/LayoutContainer.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <LayoutContainer> to render 1`] = `
+<LayoutContainer
+  className="cool-stuff"
+  fullWidth={false}
+>
+  <div
+    className="gds-layout__container cool-stuff"
+  >
+    <div>
+      Content
+    </div>
+  </div>
+</LayoutContainer>
+`;
+
+exports[`Expect <LayoutContainer> to render as full width 1`] = `
+<LayoutContainer
+  className="cool-stuff"
+  fullWidth={true}
+>
+  <div
+    className="gds-layout__container cool-stuff gds-layout__container--full-width"
+  >
+    <div>
+      Content
+    </div>
+  </div>
+</LayoutContainer>
+`;

--- a/_tests/layout/__snapshots__/Row.test.js.snap
+++ b/_tests/layout/__snapshots__/Row.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Row> to render 1`] = `
+<Row
+  className="cool-stuff"
+>
+  <div
+    className="gds-layout__row cool-stuff"
+  >
+    <div>
+      Content
+    </div>
+  </div>
+</Row>
+`;

--- a/_tests/molecules/Accordion.test.js
+++ b/_tests/molecules/Accordion.test.js
@@ -1,0 +1,21 @@
+/* globals mount */
+import React from 'react';
+import Accordion from '../../components/molecules/Accordion';
+
+describe('Expect <Accordion>', () => {
+    it('to render', () => {
+        const props = {
+            context: 'primary',
+            size: 'sm',
+            className: 'cool-stuff'
+        };
+        const wrapper = mount(
+            <Accordion {...props}>
+                <li>Accordion Item 1</li>
+                <li>Accordion Item 2</li>
+                <li>Accordion Item 3</li>
+            </Accordion>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Avatar.test.js
+++ b/_tests/molecules/Avatar.test.js
@@ -1,0 +1,38 @@
+/* globals mount */
+import React from 'react';
+import Avatar from '../../components/molecules/Avatar';
+
+const defaultProps = {
+    open: false,
+    menuCallback: () => {},
+    optionCallback: () => {},
+    username: 'Kenny',
+    img: 'http://foo.com',
+    menuOptions: [
+        {
+            name: 'test',
+            path: '/test'
+        },
+        {
+            name: 'moar',
+            path: '/more'
+        }
+    ],
+    className: 'custom-class',
+    style: { width: '100px' }
+};
+
+describe('Expect <Avatar>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Avatar {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+    it('to render opened', () => {
+        const props = {
+            ...defaultProps,
+            open: true
+        };
+        const wrapper = mount(<Avatar {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Breadcrumb.test.js
+++ b/_tests/molecules/Breadcrumb.test.js
@@ -1,0 +1,48 @@
+/* globals mount */
+import React from 'react';
+import Breadcrumb from '../../components/molecules/Breadcrumb';
+import BreadcrumbLink from '../../components/molecules/BreadcrumbLink';
+
+const defaultProps = {
+    title: 'Breadcrumb Title',
+    pathname: '/foo/bar/fat/bat',
+    path: 'woohoos',
+    subpaths: [{ title: 'Cool', path: 'cool' }, { title: 'Cool', path: 'wow' }],
+    isLast: false,
+    linkComponent: BreadcrumbLink,
+    className: 'custom-class'
+};
+
+describe('Expect <Breadcrumb>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Breadcrumb {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render as last', () => {
+        const props = {
+            ...defaultProps,
+            isLast: true
+        };
+        const wrapper = mount(<Breadcrumb {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render without subpath menu', () => {
+        const props = {
+            ...defaultProps,
+            subpaths: null
+        };
+        const wrapper = mount(<Breadcrumb {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render with hidden menus', () => {
+        const props = {
+            ...defaultProps,
+            hideMenus: true
+        };
+        const wrapper = mount(<Breadcrumb {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/BreadcrumbMenu.test.js
+++ b/_tests/molecules/BreadcrumbMenu.test.js
@@ -1,0 +1,26 @@
+/* globals mount */
+import React from 'react';
+import BreadcrumbMenu from '../../components/molecules/BreadcrumbMenu';
+import BreadcrumbLink from '../../components/molecules/BreadcrumbLink';
+
+const defaultProps = {
+    path: '/foo/bar', // parent path
+    menu: [
+        {
+            title: 'Test 1',
+            path: 'test'
+        },
+        {
+            title: 'Test 2',
+            path: 'test/test'
+        }
+    ],
+    linkComponent: BreadcrumbLink
+};
+
+describe('Expect <BreadcrumbMenu>', () => {
+    it('to render', () => {
+        const wrapper = mount(<BreadcrumbMenu {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Breadsrumbs.test.js
+++ b/_tests/molecules/Breadsrumbs.test.js
@@ -1,0 +1,67 @@
+/* globals mount */
+import React from 'react';
+import Breadcrumbs from '../../components/molecules/Breadcrumbs';
+
+const defaultProps = {
+    className: 'cool-crumbs',
+    pathname: '/home/category/subcategory-2',
+    config: {
+        title: 'Start',
+        path: '/',
+        subpaths: [
+            {
+                title: 'Home',
+                path: 'home',
+                subpaths: [
+                    {
+                        title: 'Main Category',
+                        path: 'category',
+                        subpaths: [
+                            {
+                                title: 'Sub Category 1',
+                                path: 'subcategory-1'
+                            },
+                            {
+                                title: 'Sub Category 2',
+                                path: 'subcategory-2'
+                            },
+                            {
+                                title: 'Sub Category 3',
+                                path: 'subcategory-3'
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    titleDecorator: () => {},
+    hideMenus: false,
+    hideRoot: false
+};
+
+describe('Expect <Breadcrumbs>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Breadcrumbs {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render a different path', () => {
+        const props = {
+            ...defaultProps,
+            pathname: '/home'
+        };
+        const wrapper = mount(<Breadcrumbs {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render hidden root and menus', () => {
+        const props = {
+            ...defaultProps,
+            hiddenMenus: true,
+            hideRoot: true
+        };
+        const wrapper = mount(<Breadcrumbs {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Card.test.js
+++ b/_tests/molecules/Card.test.js
@@ -1,0 +1,21 @@
+/* globals mount */
+import React from 'react';
+import Card from '../../components/molecules/Card';
+
+const defaultProps = {
+    option: 'underlined-secondary',
+    size: 'sm',
+    className: 'custom',
+    style: { width: 120 }
+};
+
+describe('Expect <Card>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <Card {...defaultProps}>
+                <div>Foo</div>
+            </Card>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/CardBlock.test.js
+++ b/_tests/molecules/CardBlock.test.js
@@ -1,0 +1,20 @@
+/* globals mount */
+import React from 'react';
+import CardBlock from '../../components/molecules/CardBlock';
+
+const defaultProps = {
+    option: 'divide-top',
+    className: 'custom',
+    style: { width: 120 }
+};
+
+describe('Expect <CardBlock>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <CardBlock {...defaultProps}>
+                <div>Foo</div>
+            </CardBlock>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/CardImage.test.js
+++ b/_tests/molecules/CardImage.test.js
@@ -1,0 +1,18 @@
+/* globals mount */
+import React from 'react';
+import CardImage from '../../components/molecules/CardImage';
+
+const defaultProps = {
+    option: 'top',
+    className: 'custom',
+    size: 'xl',
+    style: { width: 120 },
+    url: 'https://foo.bar'
+};
+
+describe('Expect <CardImage>', () => {
+    it('to render', () => {
+        const wrapper = mount(<CardImage {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Checkbox.test.js
+++ b/_tests/molecules/Checkbox.test.js
@@ -1,0 +1,27 @@
+/* globals mount */
+import React from 'react';
+import Checkbox from '../../components/molecules/Checkbox';
+
+const defaultProps = {
+    label: 'Check Me',
+    size: 'xs',
+    className: 'custom-class',
+    style: { width: 140 }
+};
+
+describe('Expect <Checkbox>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Checkbox {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render with other props', () => {
+        const props = {
+            ...defaultProps,
+            onChange: () => {},
+            value: 'foo'
+        };
+        const wrapper = mount(<Checkbox {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Divider.test.js
+++ b/_tests/molecules/Divider.test.js
@@ -1,0 +1,29 @@
+/* globals mount */
+import React from 'react';
+import Divider from '../../components/molecules/Divider';
+
+const defaultProps = {
+    label: 'Divider Label',
+    centered: false,
+    collapsible: false,
+    open: false,
+    callback: () => {},
+    style: { width: 150 }
+};
+
+describe('Expect <Divider>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Divider {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render open', () => {
+        const props = {
+            ...defaultProps,
+            collapsible: false,
+            open: true
+        };
+        const wrapper = mount(<Divider {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/FormGroup.test.js
+++ b/_tests/molecules/FormGroup.test.js
@@ -1,0 +1,47 @@
+/* globals mount */
+import React from 'react';
+import FormGroup from '../../components/molecules/FormGroup';
+
+const defaultProps = {
+    isInline: false,
+    isDisabled: false,
+    context: 'warning',
+    className: 'custom-class'
+};
+
+describe('Expect <FormGroup>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <FormGroup {...defaultProps}>
+                <input type="text" />
+            </FormGroup>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render disabled', () => {
+        const props = {
+            ...defaultProps,
+            isDisabled: true
+        };
+        const wrapper = mount(
+            <FormGroup {...props}>
+                <input type="text" />
+            </FormGroup>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render inline', () => {
+        const props = {
+            ...defaultProps,
+            isInline: true
+        };
+        const wrapper = mount(
+            <FormGroup {...props}>
+                <input type="text" />
+            </FormGroup>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/LoginForm.test.js
+++ b/_tests/molecules/LoginForm.test.js
@@ -1,0 +1,22 @@
+/* globals mount */
+import React from 'react';
+import LoginForm from '../../components/molecules/LoginForm';
+
+const defaultProps = {
+    capText: 'Text',
+    logoText: 'Logo Text',
+    onSubmit: () => {},
+    recoveryFn: () => {},
+    recoveryText: 'Recovery message'
+};
+
+describe('Expect <LoginForm>', () => {
+    it('to render', () => {
+        const wrapper = mount(
+            <LoginForm {...defaultProps}>
+                <input type="text" />
+            </LoginForm>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/MultiSelect.test.js
+++ b/_tests/molecules/MultiSelect.test.js
@@ -1,0 +1,24 @@
+/* globals mount */
+import React from 'react';
+import MultiSelect from '../../components/molecules/MultiSelect';
+
+const defaultProps = {
+    options: [
+        {
+            name: 'Name',
+            value: 10,
+            selected: true
+        }
+    ],
+    callback: () => {},
+    placeholder: 'placeholder',
+    size: 'xs',
+    className: 'custom-class'
+};
+
+describe('Expect <MultiSelect>', () => {
+    it('to render', () => {
+        const wrapper = mount(<MultiSelect {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Pagination.test.js
+++ b/_tests/molecules/Pagination.test.js
@@ -1,0 +1,30 @@
+/* globals mount */
+import React from 'react';
+import Pagination from '../../components/molecules/Pagination';
+
+const defaultProps = {
+    onChange: () => {},
+    lastPage: 100,
+    activePage: 6,
+    boundaries: false,
+    justify: false,
+    size: 'sm',
+    className: 'custom-class'
+};
+
+describe('Expect <Pagination>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Pagination {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render with boundaries and justify', () => {
+        const props = {
+            ...defaultProps,
+            boundaries: true,
+            justify: true
+        };
+        const wrapper = mount(<Pagination {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/SearchMultiSelect.test.js
+++ b/_tests/molecules/SearchMultiSelect.test.js
@@ -1,0 +1,28 @@
+/* globals mount */
+import React from 'react';
+import SearchMultiSelect from '../../components/molecules/SearchMultiSelect';
+
+const defaultProps = {
+    options: [
+        {
+            name: 'Name',
+            key: 10,
+            isSelected: true
+        }
+    ],
+    onChange: () => {},
+    update: () => {},
+    placeholder: 'placeholder',
+    size: 'sm',
+    className: 'custom-class',
+    context: 'primary',
+    searchKeys: false,
+    multiTerm: false
+};
+
+describe('Expect <SearchMultiSelect>', () => {
+    it('to render', () => {
+        const wrapper = mount(<SearchMultiSelect {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Table.test.js
+++ b/_tests/molecules/Table.test.js
@@ -1,0 +1,59 @@
+/* globals mount */
+import React from 'react';
+import Table from '../../components/molecules/Table';
+
+const defaultProps = {
+    data: [
+        {
+            foo: 'Foo',
+            bar: 'Bar'
+        }
+    ],
+    columns: ['foo', 'bar'],
+    className: 'custom-class',
+    hasHeader: false,
+    isInverse: false,
+    isSecondary: false,
+    isStriped: false,
+    onRowClick: () => {},
+    size: 'lg'
+};
+
+describe('Expect <Table>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Table {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render customized', () => {
+        const props = {
+            ...defaultProps,
+            hasHeader: true,
+            isInverse: true,
+            isSecondary: true,
+            isStriped: true
+        };
+        const wrapper = mount(<Table {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render using advanced configs', () => {
+        const props = {
+            ...defaultProps,
+            columns: [
+                {
+                    key: 'foo',
+                    children: 'Foo',
+                    headingProps: { style: { width: 100, onClick: () => {} } }
+                },
+                {
+                    key: 'bar',
+                    children: 'Bar',
+                    headingProps: { style: { width: 100, onClick: () => {} } }
+                }
+            ]
+        };
+        const wrapper = mount(<Table {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Toggle.test.js
+++ b/_tests/molecules/Toggle.test.js
@@ -1,0 +1,18 @@
+/* globals mount */
+import React from 'react';
+import Toggle from '../../components/molecules/Toggle';
+
+const defaultProps = {
+    type: 'checkbox',
+    label: 'Toggle Label',
+    size: 'sm',
+    style: { width: 100 },
+    className: 'custom-class'
+};
+
+describe('Expect <Toggle>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Toggle {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/Well.test.js
+++ b/_tests/molecules/Well.test.js
@@ -1,0 +1,27 @@
+/* globals mount */
+import React from 'react';
+import Well from '../../components/molecules/Well';
+
+const defaultProps = {
+    text: 'Foo',
+    context: 'primary',
+    className: '',
+    style: { width: 100 }
+};
+
+describe('Expect <Well>', () => {
+    it('to render', () => {
+        const wrapper = mount(<Well {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to render with a button', () => {
+        const props = {
+            ...defaultProps,
+            button: false,
+            callback: () => {}
+        };
+        const wrapper = mount(<Well {...props} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/_tests/molecules/__snapshots__/Accordion.test.js.snap
+++ b/_tests/molecules/__snapshots__/Accordion.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Accordion> to render 1`] = `
+<Accordion
+  className="cool-stuff"
+  context="primary"
+  size="sm"
+>
+  <div
+    className="gds-accordion cool-stuff gds-accordion--primary"
+  >
+    <ul
+      className="gds-accordion-list"
+    >
+      <li
+        context="primary"
+        key=".0"
+        size="sm"
+      >
+        Accordion Item 1
+      </li>
+      <li
+        context="primary"
+        key=".1"
+        size="sm"
+      >
+        Accordion Item 2
+      </li>
+      <li
+        context="primary"
+        key=".2"
+        size="sm"
+      >
+        Accordion Item 3
+      </li>
+    </ul>
+  </div>
+</Accordion>
+`;

--- a/_tests/molecules/__snapshots__/Avatar.test.js.snap
+++ b/_tests/molecules/__snapshots__/Avatar.test.js.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Avatar> to render 1`] = `
+<Avatar
+  className="custom-class"
+  img="http://foo.com"
+  menuCallback={[Function]}
+  menuOptions={
+    Array [
+      Object {
+        "name": "test",
+        "path": "/test",
+      },
+      Object {
+        "name": "moar",
+        "path": "/more",
+      },
+    ]
+  }
+  open={false}
+  optionCallback={[Function]}
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+  username="Kenny"
+>
+  <div
+    aria-controls="Avatar-region-QXZhdGFy0"
+    aria-expanded={false}
+    aria-label="Open menu options"
+    aria-pressed={false}
+    className="gds-avatar custom-class"
+    id="Avatar-label-QXZhdGFy0"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+    tabIndex={0}
+  >
+    <div
+      className="gds-avatar__image"
+    >
+      <img
+        alt="Kenny"
+        height="100%"
+        src="http://foo.com"
+      />
+    </div>
+    <nav
+      aria-labelledby="Avatar-label-QXZhdGFy0"
+      className="gds-avatar__menu"
+      id="Avatar-region-QXZhdGFy0"
+    >
+      <ul
+        className="gds-avatar__menu-list"
+      >
+        <li
+          className="gds-avatar__menu-list-item -color-tx-lt-5 -ellipsis -p-h-3 -p-v-2"
+        >
+          Kenny
+        </li>
+        <li
+          className="gds-avatar__menu-list-divider"
+        />
+        <li
+          className="gds-avatar__menu-list-item -ellipsis"
+          key="menu-item-0"
+        >
+          <div
+            className="gds-avatar__menu-list-link"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={-1}
+          >
+            test
+          </div>
+        </li>
+        <li
+          className="gds-avatar__menu-list-item -ellipsis"
+          key="menu-item-1"
+        >
+          <div
+            className="gds-avatar__menu-list-link"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={-1}
+          >
+            moar
+          </div>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</Avatar>
+`;
+
+exports[`Expect <Avatar> to render opened 1`] = `
+<Avatar
+  className="custom-class"
+  img="http://foo.com"
+  menuCallback={[Function]}
+  menuOptions={
+    Array [
+      Object {
+        "name": "test",
+        "path": "/test",
+      },
+      Object {
+        "name": "moar",
+        "path": "/more",
+      },
+    ]
+  }
+  open={true}
+  optionCallback={[Function]}
+  style={
+    Object {
+      "width": "100px",
+    }
+  }
+  username="Kenny"
+>
+  <div
+    aria-controls="Avatar-region-QXZhdGFy1"
+    aria-expanded={true}
+    aria-label="Close menu options"
+    aria-pressed={true}
+    className="gds-avatar custom-class gds-avatar--menu-open"
+    id="Avatar-label-QXZhdGFy1"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    style={
+      Object {
+        "width": "100px",
+      }
+    }
+    tabIndex={0}
+  >
+    <div
+      className="gds-avatar__image"
+    >
+      <img
+        alt="Kenny"
+        height="100%"
+        src="http://foo.com"
+      />
+    </div>
+    <nav
+      aria-labelledby="Avatar-label-QXZhdGFy1"
+      className="gds-avatar__menu"
+      id="Avatar-region-QXZhdGFy1"
+    >
+      <ul
+        className="gds-avatar__menu-list"
+      >
+        <li
+          className="gds-avatar__menu-list-item -color-tx-lt-5 -ellipsis -p-h-3 -p-v-2"
+        >
+          Kenny
+        </li>
+        <li
+          className="gds-avatar__menu-list-divider"
+        />
+        <li
+          className="gds-avatar__menu-list-item -ellipsis"
+          key="menu-item-0"
+        >
+          <div
+            className="gds-avatar__menu-list-link"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            test
+          </div>
+        </li>
+        <li
+          className="gds-avatar__menu-list-item -ellipsis"
+          key="menu-item-1"
+        >
+          <div
+            className="gds-avatar__menu-list-link"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            moar
+          </div>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</Avatar>
+`;

--- a/_tests/molecules/__snapshots__/Breadcrumb.test.js.snap
+++ b/_tests/molecules/__snapshots__/Breadcrumb.test.js.snap
@@ -1,0 +1,273 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Breadcrumb> to render 1`] = `
+<Breadcrumb
+  className="custom-class"
+  isLast={false}
+  linkComponent={[Function]}
+  path="woohoos"
+  pathname="/foo/bar/fat/bat"
+  subpaths={
+    Array [
+      Object {
+        "path": "cool",
+        "title": "Cool",
+      },
+      Object {
+        "path": "wow",
+        "title": "Cool",
+      },
+    ]
+  }
+  title="Breadcrumb Title"
+>
+  <li
+    className="gds-page-header__breadcrumbs-list-item custom-class gds-page-header__breadcrumbs-list-item--has-menu"
+  >
+    <BreadcrumbMenu
+      linkComponent={[Function]}
+      menu={
+        Array [
+          Object {
+            "path": "cool",
+            "title": "Cool",
+          },
+          Object {
+            "path": "wow",
+            "title": "Cool",
+          },
+        ]
+      }
+      path="woohoos"
+    >
+      <div
+        className="gds-page-header__breadcrumbs-menu"
+        onClick={[Function]}
+      >
+        <div
+          className="gds-page-header__breadcrumbs-menu-dots"
+        />
+        <div
+          className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+        >
+          <ul
+            className="gds-bubble__menu-list"
+          >
+            <li
+              className="gds-bubble__menu-list-item -ellipsis"
+              key="cool"
+            >
+              <BreadcrumbLink
+                className="gds-bubble__menu-list-link -text-tr-cap"
+                to="woohoos/cool"
+              >
+                <a
+                  className="gds-bubble__menu-list-link -text-tr-cap"
+                  href="woohoos/cool"
+                >
+                  Cool
+                </a>
+              </BreadcrumbLink>
+            </li>
+            <li
+              className="gds-bubble__menu-list-item -ellipsis"
+              key="wow"
+            >
+              <BreadcrumbLink
+                className="gds-bubble__menu-list-link -text-tr-cap"
+                to="woohoos/wow"
+              >
+                <a
+                  className="gds-bubble__menu-list-link -text-tr-cap"
+                  href="woohoos/wow"
+                >
+                  Cool
+                </a>
+              </BreadcrumbLink>
+            </li>
+          </ul>
+        </div>
+        <span>
+           
+        </span>
+      </div>
+    </BreadcrumbMenu>
+    <BreadcrumbLink
+      className="gds-page-header__breadcrumbs-link"
+      to="woohoos"
+    >
+      <a
+        className="gds-page-header__breadcrumbs-link"
+        href="woohoos"
+      >
+        Breadcrumb Title
+      </a>
+    </BreadcrumbLink>
+  </li>
+</Breadcrumb>
+`;
+
+exports[`Expect <Breadcrumb> to render as last 1`] = `
+<Breadcrumb
+  className="custom-class"
+  isLast={true}
+  linkComponent={[Function]}
+  path="woohoos"
+  pathname="/foo/bar/fat/bat"
+  subpaths={
+    Array [
+      Object {
+        "path": "cool",
+        "title": "Cool",
+      },
+      Object {
+        "path": "wow",
+        "title": "Cool",
+      },
+    ]
+  }
+  title="Breadcrumb Title"
+>
+  <li
+    className="gds-page-header__breadcrumbs-list-item custom-class gds-page-header__breadcrumbs-list-item--has-menu"
+  >
+    <BreadcrumbMenu
+      linkComponent={[Function]}
+      menu={
+        Array [
+          Object {
+            "path": "cool",
+            "title": "Cool",
+          },
+          Object {
+            "path": "wow",
+            "title": "Cool",
+          },
+        ]
+      }
+      path="woohoos"
+    >
+      <div
+        className="gds-page-header__breadcrumbs-menu"
+        onClick={[Function]}
+      >
+        <div
+          className="gds-page-header__breadcrumbs-menu-dots"
+        />
+        <div
+          className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+        >
+          <ul
+            className="gds-bubble__menu-list"
+          >
+            <li
+              className="gds-bubble__menu-list-item -ellipsis"
+              key="cool"
+            >
+              <BreadcrumbLink
+                className="gds-bubble__menu-list-link -text-tr-cap"
+                to="woohoos/cool"
+              >
+                <a
+                  className="gds-bubble__menu-list-link -text-tr-cap"
+                  href="woohoos/cool"
+                >
+                  Cool
+                </a>
+              </BreadcrumbLink>
+            </li>
+            <li
+              className="gds-bubble__menu-list-item -ellipsis"
+              key="wow"
+            >
+              <BreadcrumbLink
+                className="gds-bubble__menu-list-link -text-tr-cap"
+                to="woohoos/wow"
+              >
+                <a
+                  className="gds-bubble__menu-list-link -text-tr-cap"
+                  href="woohoos/wow"
+                >
+                  Cool
+                </a>
+              </BreadcrumbLink>
+            </li>
+          </ul>
+        </div>
+        <span>
+           
+        </span>
+      </div>
+    </BreadcrumbMenu>
+    Breadcrumb Title
+  </li>
+</Breadcrumb>
+`;
+
+exports[`Expect <Breadcrumb> to render with hidden menus 1`] = `
+<Breadcrumb
+  className="custom-class"
+  hideMenus={true}
+  isLast={false}
+  linkComponent={[Function]}
+  path="woohoos"
+  pathname="/foo/bar/fat/bat"
+  subpaths={
+    Array [
+      Object {
+        "path": "cool",
+        "title": "Cool",
+      },
+      Object {
+        "path": "wow",
+        "title": "Cool",
+      },
+    ]
+  }
+  title="Breadcrumb Title"
+>
+  <li
+    className="gds-page-header__breadcrumbs-list-item custom-class"
+  >
+    <BreadcrumbLink
+      className="gds-page-header__breadcrumbs-link"
+      to="woohoos"
+    >
+      <a
+        className="gds-page-header__breadcrumbs-link"
+        href="woohoos"
+      >
+        Breadcrumb Title
+      </a>
+    </BreadcrumbLink>
+  </li>
+</Breadcrumb>
+`;
+
+exports[`Expect <Breadcrumb> to render without subpath menu 1`] = `
+<Breadcrumb
+  className="custom-class"
+  isLast={false}
+  linkComponent={[Function]}
+  path="woohoos"
+  pathname="/foo/bar/fat/bat"
+  subpaths={null}
+  title="Breadcrumb Title"
+>
+  <li
+    className="gds-page-header__breadcrumbs-list-item custom-class"
+  >
+    <BreadcrumbLink
+      className="gds-page-header__breadcrumbs-link"
+      to="woohoos"
+    >
+      <a
+        className="gds-page-header__breadcrumbs-link"
+        href="woohoos"
+      >
+        Breadcrumb Title
+      </a>
+    </BreadcrumbLink>
+  </li>
+</Breadcrumb>
+`;

--- a/_tests/molecules/__snapshots__/BreadcrumbMenu.test.js.snap
+++ b/_tests/molecules/__snapshots__/BreadcrumbMenu.test.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <BreadcrumbMenu> to render 1`] = `
+<BreadcrumbMenu
+  linkComponent={[Function]}
+  menu={
+    Array [
+      Object {
+        "path": "test",
+        "title": "Test 1",
+      },
+      Object {
+        "path": "test/test",
+        "title": "Test 2",
+      },
+    ]
+  }
+  path="/foo/bar"
+>
+  <div
+    className="gds-page-header__breadcrumbs-menu"
+    onClick={[Function]}
+  >
+    <div
+      className="gds-page-header__breadcrumbs-menu-dots"
+    />
+    <div
+      className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+    >
+      <ul
+        className="gds-bubble__menu-list"
+      >
+        <li
+          className="gds-bubble__menu-list-item -ellipsis"
+          key="test"
+        >
+          <BreadcrumbLink
+            className="gds-bubble__menu-list-link -text-tr-cap"
+            to="/foo/bar/test"
+          >
+            <a
+              className="gds-bubble__menu-list-link -text-tr-cap"
+              href="/foo/bar/test"
+            >
+              Test 1
+            </a>
+          </BreadcrumbLink>
+        </li>
+        <li
+          className="gds-bubble__menu-list-item -ellipsis"
+          key="test/test"
+        >
+          <BreadcrumbLink
+            className="gds-bubble__menu-list-link -text-tr-cap"
+            to="/foo/bar/test/test"
+          >
+            <a
+              className="gds-bubble__menu-list-link -text-tr-cap"
+              href="/foo/bar/test/test"
+            >
+              Test 2
+            </a>
+          </BreadcrumbLink>
+        </li>
+      </ul>
+    </div>
+    <span>
+       
+    </span>
+  </div>
+</BreadcrumbMenu>
+`;

--- a/_tests/molecules/__snapshots__/Breadsrumbs.test.js.snap
+++ b/_tests/molecules/__snapshots__/Breadsrumbs.test.js.snap
@@ -1,0 +1,655 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Breadcrumbs> to render 1`] = `
+<Breadcrumbs
+  className="cool-crumbs"
+  config={
+    Object {
+      "path": "/",
+      "subpaths": Array [
+        Object {
+          "path": "home",
+          "subpaths": Array [
+            Object {
+              "path": "category",
+              "subpaths": Array [
+                Object {
+                  "path": "subcategory-1",
+                  "title": "Sub Category 1",
+                },
+                Object {
+                  "path": "subcategory-2",
+                  "title": "Sub Category 2",
+                },
+                Object {
+                  "path": "subcategory-3",
+                  "title": "Sub Category 3",
+                },
+              ],
+              "title": "Main Category",
+            },
+          ],
+          "title": "Home",
+        },
+      ],
+      "title": "Start",
+    }
+  }
+  hideMenus={false}
+  hideRoot={false}
+  linkComponent={[Function]}
+  pathname="/home/category/subcategory-2"
+  titleDecorator={[Function]}
+>
+  <BreadcrumbsWrapper>
+    <div
+      className="gds-page-header__breadcrumb-nav"
+    >
+      <ul
+        className="gds-page-header__breadcrumbs"
+      >
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/"
+          linkComponent={[Function]}
+          path="/"
+          pathname="/home/category/subcategory-2"
+          title="Start"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/"
+              >
+                Start
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/home"
+          linkComponent={[Function]}
+          path="/home"
+          pathname="/home/category/subcategory-2"
+          subpaths={
+            Array [
+              Object {
+                "path": "category",
+                "subpaths": Array [
+                  Object {
+                    "path": "subcategory-1",
+                    "title": "Sub Category 1",
+                  },
+                  Object {
+                    "path": "subcategory-2",
+                    "title": "Sub Category 2",
+                  },
+                  Object {
+                    "path": "subcategory-3",
+                    "title": "Sub Category 3",
+                  },
+                ],
+                "title": "Main Category",
+              },
+            ]
+          }
+          title="Home"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/home"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/home"
+              >
+                Home
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/home/category"
+          linkComponent={[Function]}
+          path="/home/category"
+          pathname="/home/category/subcategory-2"
+          subpaths={
+            Array [
+              Object {
+                "path": "subcategory-1",
+                "title": "Sub Category 1",
+              },
+              Object {
+                "path": "subcategory-2",
+                "title": "Sub Category 2",
+              },
+              Object {
+                "path": "subcategory-3",
+                "title": "Sub Category 3",
+              },
+            ]
+          }
+          title="Main Category"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item gds-page-header__breadcrumbs-list-item--has-menu"
+          >
+            <BreadcrumbMenu
+              linkComponent={[Function]}
+              menu={
+                Array [
+                  Object {
+                    "path": "subcategory-1",
+                    "title": "Sub Category 1",
+                  },
+                  Object {
+                    "path": "subcategory-3",
+                    "title": "Sub Category 3",
+                  },
+                ]
+              }
+              path="/home/category"
+            >
+              <div
+                className="gds-page-header__breadcrumbs-menu"
+                onClick={[Function]}
+              >
+                <div
+                  className="gds-page-header__breadcrumbs-menu-dots"
+                />
+                <div
+                  className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+                >
+                  <ul
+                    className="gds-bubble__menu-list"
+                  >
+                    <li
+                      className="gds-bubble__menu-list-item -ellipsis"
+                      key="subcategory-1"
+                    >
+                      <BreadcrumbLink
+                        className="gds-bubble__menu-list-link -text-tr-cap"
+                        to="/home/category/subcategory-1"
+                      >
+                        <a
+                          className="gds-bubble__menu-list-link -text-tr-cap"
+                          href="/home/category/subcategory-1"
+                        >
+                          Sub Category 1
+                        </a>
+                      </BreadcrumbLink>
+                    </li>
+                    <li
+                      className="gds-bubble__menu-list-item -ellipsis"
+                      key="subcategory-3"
+                    >
+                      <BreadcrumbLink
+                        className="gds-bubble__menu-list-link -text-tr-cap"
+                        to="/home/category/subcategory-3"
+                      >
+                        <a
+                          className="gds-bubble__menu-list-link -text-tr-cap"
+                          href="/home/category/subcategory-3"
+                        >
+                          Sub Category 3
+                        </a>
+                      </BreadcrumbLink>
+                    </li>
+                  </ul>
+                </div>
+                <span>
+                   
+                </span>
+              </div>
+            </BreadcrumbMenu>
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/home/category"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/home/category"
+              >
+                Main Category
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={true}
+          key="/home/category/subcategory-2"
+          linkComponent={[Function]}
+          path="/home/category/subcategory-2"
+          pathname="/home/category/subcategory-2"
+          title="Sub Category 2"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            Sub Category 2
+          </li>
+        </Breadcrumb>
+      </ul>
+    </div>
+  </BreadcrumbsWrapper>
+</Breadcrumbs>
+`;
+
+exports[`Expect <Breadcrumbs> to render a different path 1`] = `
+<Breadcrumbs
+  className="cool-crumbs"
+  config={
+    Object {
+      "path": "/",
+      "subpaths": Array [
+        Object {
+          "path": "home",
+          "subpaths": Array [
+            Object {
+              "path": "category",
+              "subpaths": Array [
+                Object {
+                  "path": "subcategory-1",
+                  "title": "Sub Category 1",
+                },
+                Object {
+                  "path": "subcategory-2",
+                  "title": "Sub Category 2",
+                },
+                Object {
+                  "path": "subcategory-3",
+                  "title": "Sub Category 3",
+                },
+              ],
+              "title": "Main Category",
+            },
+          ],
+          "title": "Home",
+        },
+      ],
+      "title": "Start",
+    }
+  }
+  hideMenus={false}
+  hideRoot={false}
+  linkComponent={[Function]}
+  pathname="/home"
+  titleDecorator={[Function]}
+>
+  <BreadcrumbsWrapper>
+    <div
+      className="gds-page-header__breadcrumb-nav"
+    >
+      <ul
+        className="gds-page-header__breadcrumbs"
+      >
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/"
+          linkComponent={[Function]}
+          path="/"
+          pathname="/home"
+          title="Start"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/"
+              >
+                Start
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={true}
+          key="/home"
+          linkComponent={[Function]}
+          path="/home"
+          pathname="/home"
+          subpaths={
+            Array [
+              Object {
+                "path": "category",
+                "subpaths": Array [
+                  Object {
+                    "path": "subcategory-1",
+                    "title": "Sub Category 1",
+                  },
+                  Object {
+                    "path": "subcategory-2",
+                    "title": "Sub Category 2",
+                  },
+                  Object {
+                    "path": "subcategory-3",
+                    "title": "Sub Category 3",
+                  },
+                ],
+                "title": "Main Category",
+              },
+            ]
+          }
+          title="Home"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item gds-page-header__breadcrumbs-list-item--has-menu"
+          >
+            <BreadcrumbMenu
+              linkComponent={[Function]}
+              menu={
+                Array [
+                  Object {
+                    "path": "category",
+                    "subpaths": Array [
+                      Object {
+                        "path": "subcategory-1",
+                        "title": "Sub Category 1",
+                      },
+                      Object {
+                        "path": "subcategory-2",
+                        "title": "Sub Category 2",
+                      },
+                      Object {
+                        "path": "subcategory-3",
+                        "title": "Sub Category 3",
+                      },
+                    ],
+                    "title": "Main Category",
+                  },
+                ]
+              }
+              path="/home"
+            >
+              <div
+                className="gds-page-header__breadcrumbs-menu"
+                onClick={[Function]}
+              >
+                <div
+                  className="gds-page-header__breadcrumbs-menu-dots"
+                />
+                <div
+                  className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+                >
+                  <ul
+                    className="gds-bubble__menu-list"
+                  >
+                    <li
+                      className="gds-bubble__menu-list-item -ellipsis"
+                      key="category"
+                    >
+                      <BreadcrumbLink
+                        className="gds-bubble__menu-list-link -text-tr-cap"
+                        to="/home/category"
+                      >
+                        <a
+                          className="gds-bubble__menu-list-link -text-tr-cap"
+                          href="/home/category"
+                        >
+                          Main Category
+                        </a>
+                      </BreadcrumbLink>
+                    </li>
+                  </ul>
+                </div>
+                <span>
+                   
+                </span>
+              </div>
+            </BreadcrumbMenu>
+            Home
+          </li>
+        </Breadcrumb>
+      </ul>
+    </div>
+  </BreadcrumbsWrapper>
+</Breadcrumbs>
+`;
+
+exports[`Expect <Breadcrumbs> to render hidden root and menus 1`] = `
+<Breadcrumbs
+  className="cool-crumbs"
+  config={
+    Object {
+      "path": "/",
+      "subpaths": Array [
+        Object {
+          "path": "home",
+          "subpaths": Array [
+            Object {
+              "path": "category",
+              "subpaths": Array [
+                Object {
+                  "path": "subcategory-1",
+                  "title": "Sub Category 1",
+                },
+                Object {
+                  "path": "subcategory-2",
+                  "title": "Sub Category 2",
+                },
+                Object {
+                  "path": "subcategory-3",
+                  "title": "Sub Category 3",
+                },
+              ],
+              "title": "Main Category",
+            },
+          ],
+          "title": "Home",
+        },
+      ],
+      "title": "Start",
+    }
+  }
+  hiddenMenus={true}
+  hideMenus={false}
+  hideRoot={true}
+  linkComponent={[Function]}
+  pathname="/home/category/subcategory-2"
+  titleDecorator={[Function]}
+>
+  <BreadcrumbsWrapper>
+    <div
+      className="gds-page-header__breadcrumb-nav"
+    >
+      <ul
+        className="gds-page-header__breadcrumbs"
+      >
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/home"
+          linkComponent={[Function]}
+          path="/home"
+          pathname="/home/category/subcategory-2"
+          subpaths={
+            Array [
+              Object {
+                "path": "category",
+                "subpaths": Array [
+                  Object {
+                    "path": "subcategory-1",
+                    "title": "Sub Category 1",
+                  },
+                  Object {
+                    "path": "subcategory-2",
+                    "title": "Sub Category 2",
+                  },
+                  Object {
+                    "path": "subcategory-3",
+                    "title": "Sub Category 3",
+                  },
+                ],
+                "title": "Main Category",
+              },
+            ]
+          }
+          title="Home"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/home"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/home"
+              >
+                Home
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={false}
+          key="/home/category"
+          linkComponent={[Function]}
+          path="/home/category"
+          pathname="/home/category/subcategory-2"
+          subpaths={
+            Array [
+              Object {
+                "path": "subcategory-1",
+                "title": "Sub Category 1",
+              },
+              Object {
+                "path": "subcategory-2",
+                "title": "Sub Category 2",
+              },
+              Object {
+                "path": "subcategory-3",
+                "title": "Sub Category 3",
+              },
+            ]
+          }
+          title="Main Category"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item gds-page-header__breadcrumbs-list-item--has-menu"
+          >
+            <BreadcrumbMenu
+              linkComponent={[Function]}
+              menu={
+                Array [
+                  Object {
+                    "path": "subcategory-1",
+                    "title": "Sub Category 1",
+                  },
+                  Object {
+                    "path": "subcategory-3",
+                    "title": "Sub Category 3",
+                  },
+                ]
+              }
+              path="/home/category"
+            >
+              <div
+                className="gds-page-header__breadcrumbs-menu"
+                onClick={[Function]}
+              >
+                <div
+                  className="gds-page-header__breadcrumbs-menu-dots"
+                />
+                <div
+                  className="gds-bubble__menu gds-bubble__menu--left gds-bubble__menu--sm"
+                >
+                  <ul
+                    className="gds-bubble__menu-list"
+                  >
+                    <li
+                      className="gds-bubble__menu-list-item -ellipsis"
+                      key="subcategory-1"
+                    >
+                      <BreadcrumbLink
+                        className="gds-bubble__menu-list-link -text-tr-cap"
+                        to="/home/category/subcategory-1"
+                      >
+                        <a
+                          className="gds-bubble__menu-list-link -text-tr-cap"
+                          href="/home/category/subcategory-1"
+                        >
+                          Sub Category 1
+                        </a>
+                      </BreadcrumbLink>
+                    </li>
+                    <li
+                      className="gds-bubble__menu-list-item -ellipsis"
+                      key="subcategory-3"
+                    >
+                      <BreadcrumbLink
+                        className="gds-bubble__menu-list-link -text-tr-cap"
+                        to="/home/category/subcategory-3"
+                      >
+                        <a
+                          className="gds-bubble__menu-list-link -text-tr-cap"
+                          href="/home/category/subcategory-3"
+                        >
+                          Sub Category 3
+                        </a>
+                      </BreadcrumbLink>
+                    </li>
+                  </ul>
+                </div>
+                <span>
+                   
+                </span>
+              </div>
+            </BreadcrumbMenu>
+            <BreadcrumbLink
+              className="gds-page-header__breadcrumbs-link"
+              to="/home/category"
+            >
+              <a
+                className="gds-page-header__breadcrumbs-link"
+                href="/home/category"
+              >
+                Main Category
+              </a>
+            </BreadcrumbLink>
+          </li>
+        </Breadcrumb>
+        <Breadcrumb
+          hideMenus={false}
+          isLast={true}
+          key="/home/category/subcategory-2"
+          linkComponent={[Function]}
+          path="/home/category/subcategory-2"
+          pathname="/home/category/subcategory-2"
+          title="Sub Category 2"
+        >
+          <li
+            className="gds-page-header__breadcrumbs-list-item"
+          >
+            Sub Category 2
+          </li>
+        </Breadcrumb>
+      </ul>
+    </div>
+  </BreadcrumbsWrapper>
+</Breadcrumbs>
+`;

--- a/_tests/molecules/__snapshots__/Card.test.js.snap
+++ b/_tests/molecules/__snapshots__/Card.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Card> to render 1`] = `
+<Card
+  className="custom"
+  option="underlined-secondary"
+  size="sm"
+  style={
+    Object {
+      "width": 120,
+    }
+  }
+>
+  <div
+    className="gds-card custom gds-card--underlined-secondary gds-card--sm"
+    style={
+      Object {
+        "width": 120,
+      }
+    }
+  >
+    <div>
+      Foo
+    </div>
+  </div>
+</Card>
+`;

--- a/_tests/molecules/__snapshots__/CardBlock.test.js.snap
+++ b/_tests/molecules/__snapshots__/CardBlock.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <CardBlock> to render 1`] = `
+<CardBlock
+  className="custom"
+  option="divide-top"
+  style={
+    Object {
+      "width": 120,
+    }
+  }
+>
+  <div
+    className="gds-card__block custom gds-card__block--divide-top"
+    style={
+      Object {
+        "width": 120,
+      }
+    }
+  >
+    <div>
+      Foo
+    </div>
+  </div>
+</CardBlock>
+`;

--- a/_tests/molecules/__snapshots__/CardImage.test.js.snap
+++ b/_tests/molecules/__snapshots__/CardImage.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <CardImage> to render 1`] = `
+<CardImage
+  className="custom"
+  option="top"
+  size="xl"
+  style={
+    Object {
+      "width": 120,
+    }
+  }
+  url="https://foo.bar"
+>
+  <div
+    className="gds-card__img-container custom gds-card__img-container--top gds-card__img-container--xl"
+    style={
+      Object {
+        "width": 120,
+      }
+    }
+  >
+    <img
+      className="gds-card__img"
+      src="https://foo.bar"
+    />
+    <div
+      className="gds-card__img-helper"
+    />
+  </div>
+</CardImage>
+`;

--- a/_tests/molecules/__snapshots__/Checkbox.test.js.snap
+++ b/_tests/molecules/__snapshots__/Checkbox.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Checkbox> to render 1`] = `
+<Checkbox
+  className="custom-class"
+  label="Check Me"
+  size="xs"
+  style={
+    Object {
+      "width": 140,
+    }
+  }
+>
+  <div
+    className="gds-form-group__checkbox custom-class gds-form-group__checkbox--xs"
+    style={
+      Object {
+        "width": 140,
+      }
+    }
+  >
+    <label
+      className="gds-form-group__checkbox-label"
+    >
+      <input
+        className="gds-form-group__checkbox-input"
+        type="checkbox"
+      />
+      <span
+        className="gds-form-group__checkbox-indicator"
+      />
+      Check Me
+    </label>
+  </div>
+</Checkbox>
+`;
+
+exports[`Expect <Checkbox> to render with other props 1`] = `
+<Checkbox
+  className="custom-class"
+  label="Check Me"
+  onChange={[Function]}
+  size="xs"
+  style={
+    Object {
+      "width": 140,
+    }
+  }
+  value="foo"
+>
+  <div
+    className="gds-form-group__checkbox custom-class gds-form-group__checkbox--xs"
+    style={
+      Object {
+        "width": 140,
+      }
+    }
+  >
+    <label
+      className="gds-form-group__checkbox-label"
+    >
+      <input
+        className="gds-form-group__checkbox-input"
+        onChange={[Function]}
+        type="checkbox"
+        value="foo"
+      />
+      <span
+        className="gds-form-group__checkbox-indicator"
+      />
+      Check Me
+    </label>
+  </div>
+</Checkbox>
+`;

--- a/_tests/molecules/__snapshots__/Divider.test.js.snap
+++ b/_tests/molecules/__snapshots__/Divider.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Divider> to render 1`] = `
+<Divider
+  callback={[Function]}
+  centered={false}
+  collapsible={false}
+  label="Divider Label"
+  open={false}
+  style={
+    Object {
+      "width": 150,
+    }
+  }
+>
+  <div
+    className="gds-divider"
+    onClick={[Function]}
+    style={
+      Object {
+        "width": 150,
+      }
+    }
+  >
+    <span
+      className="gds-divider__label gds-form-group__label"
+    >
+      Divider Label
+    </span>
+    <span
+      className="gds-divider__line"
+    />
+  </div>
+</Divider>
+`;
+
+exports[`Expect <Divider> to render open 1`] = `
+<Divider
+  callback={[Function]}
+  centered={false}
+  collapsible={false}
+  label="Divider Label"
+  open={true}
+  style={
+    Object {
+      "width": 150,
+    }
+  }
+>
+  <div
+    className="gds-divider"
+    onClick={[Function]}
+    style={
+      Object {
+        "width": 150,
+      }
+    }
+  >
+    <span
+      className="gds-divider__label gds-form-group__label"
+    >
+      Divider Label
+    </span>
+    <span
+      className="gds-divider__line"
+    />
+  </div>
+</Divider>
+`;

--- a/_tests/molecules/__snapshots__/FormGroup.test.js.snap
+++ b/_tests/molecules/__snapshots__/FormGroup.test.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <FormGroup> to render 1`] = `
+<FormGroup
+  className="custom-class"
+  context="warning"
+  isDisabled={false}
+  isInline={false}
+>
+  <div
+    className="gds-form-group custom-class gds-form-group--warning"
+  >
+    <input
+      type="text"
+    />
+  </div>
+</FormGroup>
+`;
+
+exports[`Expect <FormGroup> to render disabled 1`] = `
+<FormGroup
+  className="custom-class"
+  context="warning"
+  isDisabled={true}
+  isInline={false}
+>
+  <div
+    className="gds-form-group custom-class gds-form-group--warning gds-form-group--disabled"
+  >
+    <input
+      type="text"
+    />
+  </div>
+</FormGroup>
+`;
+
+exports[`Expect <FormGroup> to render inline 1`] = `
+<FormGroup
+  className="custom-class"
+  context="warning"
+  isDisabled={false}
+  isInline={true}
+>
+  <div
+    className="gds-form-group custom-class gds-form-group--warning gds-form-group--inline"
+  >
+    <input
+      type="text"
+    />
+  </div>
+</FormGroup>
+`;

--- a/_tests/molecules/__snapshots__/LoginForm.test.js.snap
+++ b/_tests/molecules/__snapshots__/LoginForm.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <LoginForm> to render 1`] = `
+<LoginForm
+  capText="Text"
+  logoText="Logo Text"
+  onSubmit={[Function]}
+  recoveryFn={[Function]}
+  recoveryText="Recovery message"
+>
+  <div
+    className="gds-account-modal gds-account-modal--logo"
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      className="gds-account-modal__form gds-card -p-t-3-sm -p-t-0"
+    >
+      <div
+        className="gds-account-modal__logo-product"
+      >
+        Logo Text
+      </div>
+      <div
+        className="gds-account-modal__form-cap -m-t-3-sm -m-t-0"
+      >
+        Text
+      </div>
+      <form
+        className="gds-form -pointer-events--auto -p-a-3"
+        onSubmit={[Function]}
+      >
+        <input
+          type="text"
+        />
+      </form>
+    </div>
+    <p
+      className="gds-account-modal__extra-links"
+    >
+      <a
+        className="gds-text--link -cursor--pointer"
+        onClick={[Function]}
+      >
+        Recovery message
+      </a>
+    </p>
+  </div>
+</LoginForm>
+`;

--- a/_tests/molecules/__snapshots__/MultiSelect.test.js.snap
+++ b/_tests/molecules/__snapshots__/MultiSelect.test.js.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <MultiSelect> to render 1`] = `
+<MultiSelect
+  callback={[Function]}
+  className="custom-class"
+  options={
+    Array [
+      Object {
+        "name": "Name",
+        "selected": true,
+        "value": 10,
+      },
+    ]
+  }
+  placeholder="placeholder"
+  size="xs"
+>
+  <div
+    className="gds-multi-select custom-class gds-multi-select--xs"
+  >
+    <button
+      aria-controls="MultiSelect_region_TXVsdGlTZWxlY3Q=0"
+      aria-expanded={false}
+      aria-pressed={false}
+      className="gds-multi-select__button gds-multi-select__button--xs"
+      id="MultiSelect_label_TXVsdGlTZWxlY3Q=0"
+      onClick={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <div
+        className="-ellipsis"
+      >
+        Name
+      </div>
+    </button>
+    <ul
+      aria-hidden={true}
+      aria-labelledby="MultiSelect_label_TXVsdGlTZWxlY3Q=0"
+      className="gds-multi-select__menu"
+      id="MultiSelect_region_TXVsdGlTZWxlY3Q=0"
+      role="region"
+    >
+      <li
+        className="gds-multi-select__menu-item"
+        key="item-0"
+      >
+        <div
+          className="gds-multi-select__menu-link"
+        >
+          <div
+            className="gds-form-group gds-multi-select__option"
+          >
+            <Checkbox
+              checked={true}
+              label="Name"
+              onChange={[Function]}
+            >
+              <div
+                className="gds-form-group__checkbox"
+              >
+                <label
+                  className="gds-form-group__checkbox-label"
+                >
+                  <input
+                    checked={true}
+                    className="gds-form-group__checkbox-input"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="gds-form-group__checkbox-indicator"
+                  />
+                  Name
+                </label>
+              </div>
+            </Checkbox>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</MultiSelect>
+`;

--- a/_tests/molecules/__snapshots__/Pagination.test.js.snap
+++ b/_tests/molecules/__snapshots__/Pagination.test.js.snap
@@ -1,0 +1,435 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Pagination> to render 1`] = `
+<Pagination
+  activePage={6}
+  boundaries={false}
+  className="custom-class"
+  itemsPerPage={10}
+  justify={false}
+  lastPage={100}
+  onChange={[Function]}
+  size="sm"
+>
+  <nav
+    className="gds-pagination gds-pagination--mobile-arrows custom-class gds-pagination--fixed gds-pagination--sm"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+    >
+      <button
+        aria-label="Goto previous page"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        <span
+          className="-vis-hidden -ellipsis"
+        >
+          Go to previous page
+        </span>
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="1"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 1"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        1
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="2"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 2"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        2
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="3"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 3"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        3
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="4"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 4"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        4
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="5"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 5"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        5
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed gds-pagination__page-item--active"
+      key="6"
+    >
+      <button
+        aria-current={true}
+        aria-label="Page 6, Current"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        6
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+      key="7"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 7"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        7
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--fixed"
+    >
+      <button
+        aria-label="Goto next page"
+        className="gds-pagination__page-link -overflow-hidden gds-pagination__page-link--fixed"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": 0,
+          }
+        }
+      >
+        <span
+          className="-vis-hidden -ellipsis"
+        >
+          Go to next page
+        </span>
+      </button>
+    </div>
+    <span
+      className="gds-pagination__page-indicator"
+    />
+  </nav>
+</Pagination>
+`;
+
+exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
+<Pagination
+  activePage={6}
+  boundaries={true}
+  className="custom-class"
+  itemsPerPage={10}
+  justify={true}
+  lastPage={100}
+  onChange={[Function]}
+  size="sm"
+>
+  <nav
+    className="gds-pagination gds-pagination--mobile-arrows custom-class gds-pagination--sm"
+    onKeyDown={[Function]}
+  >
+    <div
+      className="gds-pagination__page-item -va-top"
+    >
+      <button
+        aria-label="Goto previous page"
+        className="gds-pagination__page-link -overflow-hidden"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        <span
+          className="-vis-hidden -ellipsis"
+        >
+          Go to previous page
+        </span>
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="1"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 1"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        1
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="4"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 4"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        4
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="5"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 5"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        5
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top gds-pagination__page-item--active"
+      key="6"
+    >
+      <button
+        aria-current={true}
+        aria-label="Page 6, Current"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        6
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="7"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 7"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        7
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="8"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 8"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        8
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+      key="100"
+    >
+      <button
+        aria-current={false}
+        aria-label="Goto page 100"
+        className="gds-pagination__page-link -overflow-hidden"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        100
+      </button>
+    </div>
+    <div
+      className="gds-pagination__page-item -va-top"
+    >
+      <button
+        aria-label="Goto next page"
+        className="gds-pagination__page-link -overflow-hidden"
+        disabled={false}
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "none",
+            "border": 0,
+            "fontFamily": "inherit",
+            "padding": null,
+          }
+        }
+      >
+        <span
+          className="-vis-hidden -ellipsis"
+        >
+          Go to next page
+        </span>
+      </button>
+    </div>
+    <span
+      className="gds-pagination__page-indicator"
+    />
+  </nav>
+</Pagination>
+`;

--- a/_tests/molecules/__snapshots__/SearchMultiSelect.test.js.snap
+++ b/_tests/molecules/__snapshots__/SearchMultiSelect.test.js.snap
@@ -1,0 +1,150 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <SearchMultiSelect> to render 1`] = `
+<SearchMultiSelect
+  className="custom-class"
+  context="primary"
+  filter={[Function]}
+  multiTerm={false}
+  onChange={[Function]}
+  options={
+    Array [
+      Object {
+        "isSelected": true,
+        "key": 10,
+        "name": "Name",
+      },
+    ]
+  }
+  placeholder="placeholder"
+  searchKeys={false}
+  size="sm"
+  termDivider={/\\[ ,\\]\\+/}
+  update={[Function]}
+>
+  <div
+    className="gds-search-select"
+  >
+    <div
+      className="gds-search-select__control"
+    >
+      <Tag
+        className="gds-search-select__tag-indicator"
+        context="primary"
+        hasOption={true}
+        onClick={[Function]}
+        onOptionClick={[Function]}
+        optionIcon="bt-times"
+        optionLabel="Clear all tags"
+        size="xs"
+        style={
+          Object {
+            "top": "0.4rem",
+          }
+        }
+        text="1 Selected"
+      >
+        <div
+          className="gds-tag gds-search-select__tag-indicator gds-tag--primary gds-tag--with-button gds-tag--with-button--xs gds-tag--xs"
+          onClick={[Function]}
+          style={
+            Object {
+              "top": "0.4rem",
+            }
+          }
+        >
+          1 Selected
+          <button
+            aria-label="Clear all tags"
+            className="gds-tag__option gds-tag__option--primary gds-tag__option--xs"
+            onClick={[Function]}
+          >
+            <i
+              className="btl bt-fw bt-times"
+            />
+          </button>
+        </div>
+      </Tag>
+      <input
+        className="gds-search-select__input gds-search-select__input--sm gds-search-select__input--has-tag"
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        placeholder="placeholder"
+        type="text"
+      />
+      <button
+        className="gds-search-select__toggle-button -cursor--pointer"
+        onClick={[Function]}
+        type="button"
+      />
+    </div>
+    <div
+      className="gds-search-select__tag-holder
+    gds-search-select__tag-holder--bubble "
+    >
+      <div
+        className="gds-search-select__tag-overflow"
+      >
+        <Tag
+          className="-m-a-1"
+          context="primary"
+          hasOption={true}
+          key="10"
+          onOptionClick={[Function]}
+          optionIcon="bt-times"
+          optionLabel="Remove option"
+          size="sm"
+          style={Object {}}
+          text="Name"
+        >
+          <div
+            className="gds-tag -m-a-1 gds-tag--primary gds-tag--with-button gds-tag--with-button--sm gds-tag--sm"
+            style={Object {}}
+          >
+            Name
+            <button
+              aria-label="Remove option"
+              className="gds-tag__option gds-tag__option--primary gds-tag__option--sm"
+              onClick={[Function]}
+            >
+              <i
+                className="btl bt-fw bt-times"
+              />
+            </button>
+          </div>
+        </Tag>
+      </div>
+    </div>
+    <div
+      className="gds-search-select__menu"
+    >
+      <div
+        className="gds-search-select__menu-items"
+      >
+        <div
+          className="gds-search-select__menu-item gds-search-select__menu-item--selected"
+          key="10"
+          onClick={[Function]}
+        >
+          <label
+            className="gds-search-select__checkbox"
+          >
+            <input
+              checked={true}
+              className="gds-search-select__checkbox-input"
+              name="Name"
+              readOnly={true}
+              type="checkbox"
+            />
+            <span
+              className="gds-search-select__checkbox-indicator"
+            />
+          </label>
+          Name
+        </div>
+      </div>
+    </div>
+  </div>
+</SearchMultiSelect>
+`;

--- a/_tests/molecules/__snapshots__/Table.test.js.snap
+++ b/_tests/molecules/__snapshots__/Table.test.js.snap
@@ -1,0 +1,259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Table> to render 1`] = `
+<Table
+  className="custom-class"
+  columns={
+    Array [
+      "foo",
+      "bar",
+    ]
+  }
+  data={
+    Array [
+      Object {
+        "bar": "Bar",
+        "foo": "Foo",
+      },
+    ]
+  }
+  hasHeader={false}
+  isInverse={false}
+  isSecondary={false}
+  isStriped={false}
+  onRowClick={[Function]}
+  size="lg"
+>
+  <table
+    className="gds-table custom-class gds-table--lg"
+  >
+    <TableBody>
+      <tbody
+        className=""
+      >
+        <TableRow
+          className="-cursor--pointer"
+          isInverse={false}
+          isStriped={false}
+          key="row-0"
+          onClick={[Function]}
+        >
+          <tr
+            className="gds-table__row -cursor--pointer"
+            onClick={[Function]}
+          >
+            <TableData
+              key="row-0-key-0"
+            >
+              <td
+                className=""
+              >
+                Foo
+              </td>
+            </TableData>
+            <TableData
+              key="row-0-key-1"
+            >
+              <td
+                className=""
+              >
+                Bar
+              </td>
+            </TableData>
+          </tr>
+        </TableRow>
+      </tbody>
+    </TableBody>
+  </table>
+</Table>
+`;
+
+exports[`Expect <Table> to render customized 1`] = `
+<Table
+  className="custom-class"
+  columns={
+    Array [
+      "foo",
+      "bar",
+    ]
+  }
+  data={
+    Array [
+      Object {
+        "bar": "Bar",
+        "foo": "Foo",
+      },
+    ]
+  }
+  hasHeader={true}
+  isInverse={true}
+  isSecondary={true}
+  isStriped={true}
+  onRowClick={[Function]}
+  size="lg"
+>
+  <table
+    className="gds-table custom-class gds-table--lg gds-table--inverse gds-table--inverse-striped"
+  >
+    <TableHeader>
+      <thead
+        className=""
+      >
+        <TableRow>
+          <tr
+            className="gds-table__row"
+          >
+            <TableHeading
+              isSecondary={true}
+              key="row-0-key-0"
+              onClick={[Function]}
+            >
+              <th
+                className="gds-table__header -text-left gds-table__header--secondary"
+                onClick={[Function]}
+              >
+                foo
+              </th>
+            </TableHeading>
+            <TableHeading
+              isSecondary={true}
+              key="row-1-key-1"
+              onClick={[Function]}
+            >
+              <th
+                className="gds-table__header -text-left gds-table__header--secondary"
+                onClick={[Function]}
+              >
+                bar
+              </th>
+            </TableHeading>
+          </tr>
+        </TableRow>
+      </thead>
+    </TableHeader>
+    <TableBody>
+      <tbody
+        className=""
+      >
+        <TableRow
+          className="-cursor--pointer"
+          isInverse={true}
+          isStriped={true}
+          key="row-0"
+          onClick={[Function]}
+        >
+          <tr
+            className="gds-table__row -cursor--pointer gds-table__row--inverse gds-table__row--striped-inverse"
+            onClick={[Function]}
+          >
+            <TableData
+              key="row-0-key-0"
+            >
+              <td
+                className=""
+              >
+                Foo
+              </td>
+            </TableData>
+            <TableData
+              key="row-0-key-1"
+            >
+              <td
+                className=""
+              >
+                Bar
+              </td>
+            </TableData>
+          </tr>
+        </TableRow>
+      </tbody>
+    </TableBody>
+  </table>
+</Table>
+`;
+
+exports[`Expect <Table> to render using advanced configs 1`] = `
+<Table
+  className="custom-class"
+  columns={
+    Array [
+      Object {
+        "children": "Foo",
+        "headingProps": Object {
+          "style": Object {
+            "onClick": [Function],
+            "width": 100,
+          },
+        },
+        "key": "foo",
+      },
+      Object {
+        "children": "Bar",
+        "headingProps": Object {
+          "style": Object {
+            "onClick": [Function],
+            "width": 100,
+          },
+        },
+        "key": "bar",
+      },
+    ]
+  }
+  data={
+    Array [
+      Object {
+        "bar": "Bar",
+        "foo": "Foo",
+      },
+    ]
+  }
+  hasHeader={false}
+  isInverse={false}
+  isSecondary={false}
+  isStriped={false}
+  onRowClick={[Function]}
+  size="lg"
+>
+  <table
+    className="gds-table custom-class gds-table--lg"
+  >
+    <TableBody>
+      <tbody
+        className=""
+      >
+        <TableRow
+          className="-cursor--pointer"
+          isInverse={false}
+          isStriped={false}
+          key="row-0"
+          onClick={[Function]}
+        >
+          <tr
+            className="gds-table__row -cursor--pointer"
+            onClick={[Function]}
+          >
+            <TableData
+              key="row-0-key-0"
+            >
+              <td
+                className=""
+              >
+                Foo
+              </td>
+            </TableData>
+            <TableData
+              key="row-0-key-1"
+            >
+              <td
+                className=""
+              >
+                Bar
+              </td>
+            </TableData>
+          </tr>
+        </TableRow>
+      </tbody>
+    </TableBody>
+  </table>
+</Table>
+`;

--- a/_tests/molecules/__snapshots__/Toggle.test.js.snap
+++ b/_tests/molecules/__snapshots__/Toggle.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Toggle> to render 1`] = `
+<Toggle
+  className="custom-class"
+  label="Toggle Label"
+  size="sm"
+  style={
+    Object {
+      "width": 100,
+    }
+  }
+  type="checkbox"
+>
+  <div
+    className="gds-form-group__toggleswitch custom-class gds-form-group__toggleswitch--sm"
+    style={
+      Object {
+        "width": 100,
+      }
+    }
+  >
+    <label
+      className="gds-form-group__toggleswitch-label"
+    >
+      <input
+        className="gds-form-group__toggleswitch-input"
+        type="checkbox"
+      />
+      <span
+        className="gds-form-group__toggleswitch-indicator"
+      />
+      Toggle Label
+    </label>
+  </div>
+</Toggle>
+`;

--- a/_tests/molecules/__snapshots__/Well.test.js.snap
+++ b/_tests/molecules/__snapshots__/Well.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <Well> to render 1`] = `
+<Well
+  button={false}
+  callback={null}
+  className=""
+  context="primary"
+  style={
+    Object {
+      "width": 100,
+    }
+  }
+  text="Foo"
+>
+  <div
+    className="gds-well gds-well--primary"
+    style={
+      Object {
+        "width": 100,
+      }
+    }
+  >
+    <p
+      className="gds-well__text"
+    >
+      Foo
+    </p>
+  </div>
+</Well>
+`;
+
+exports[`Expect <Well> to render with a button 1`] = `
+<Well
+  button={false}
+  callback={[Function]}
+  className=""
+  context="primary"
+  style={
+    Object {
+      "width": 100,
+    }
+  }
+  text="Foo"
+>
+  <div
+    className="gds-well gds-well--primary"
+    style={
+      Object {
+        "width": 100,
+      }
+    }
+  >
+    <p
+      className="gds-well__text"
+    >
+      Foo
+    </p>
+  </div>
+</Well>
+`;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,26 @@
         "publish-pack": "env PUBLISH_PACK=1 node tools/build",
         "prepare": "npm run build",
         "lint": "eslint ./components --color",
-        "test": "snyk test && storyshots",
+        "test": "NODE_ENV='test' jest",
+        "test:watch": "NODE_ENV='test' jest --watch",
         "preclean": "rimraf node_modules",
         "clean": "yarn cache clean && yarn install",
         "prettier": "prettier \"*/**/*.{js,jsx,json,css,scss}\" --ignore-path ./.prettierignore --write && git status"
+    },
+    "jest": {
+        "setupFiles": [
+            "<rootDir>/_tests/jestSetup.js"
+        ],
+        "snapshotSerializers": [
+            "enzyme-to-json/serializer"
+        ],
+        "moduleDirectories": [
+            "node_modules"
+        ],
+        "testMatch": [
+            "**/?(*.)+(spec|test).js?(x)"
+        ],
+        "modulePathIgnorePatterns": ["<rootDir>/dist/"]
     },
     "pre-commit": [
         "prettier"
@@ -48,6 +64,7 @@
         "babel-cli": "^6.26.0",
         "babel-core": "^6.26.3",
         "babel-eslint": "^8.2.3",
+        "babel-jest": "^23.4.0",
         "babel-plugin-external-helpers": "^6.22.0",
         "babel-plugin-istanbul": "^4.1.6",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
@@ -57,9 +74,13 @@
         "babel-preset-react": "^6.24.1",
         "babel-preset-stage-0": "^6.24.1",
         "babel-runtime": "^6.26.0",
+        "enzyme": "^3.3.0",
+        "enzyme-adapter-react-16": "^1.1.1",
+        "enzyme-to-json": "^3.3.1",
         "eslint-plugin-react": "^6.10.3",
         "eslint": "^3.18.0",
-        "jest-cli": "^19.0.2",
+        "jest": "^23.4.1",
+        "jest-cli": "^23.4.1",
         "prettier": "1.10.2",
         "prop-types": "^15.6.1",
         "raw-loader": "^0.5.1",

--- a/tools/build.js
+++ b/tools/build.js
@@ -212,6 +212,25 @@ function moveFile(oldPath, newPath) {
     });
 }
 
+// Run tests
+async function runTests() {
+    log('Running Tests');
+    const childProcess = spawn('npm', ['run', 'test']);
+    return new Promise((resolve, reject) => {
+        childProcess.on('error', err => {
+            reject(err);
+        });
+        childProcess.on('close', code => {
+            if (code > 0) {
+                reject('🛑 Tests failed');
+            } else {
+                console.log('✅ Tests Pass');
+                resolve();
+            }
+        });
+    });
+}
+
 // Create a Tarball of the dist/ dir
 async function packDistDir() {
     log('Packing dist/ directory');
@@ -258,6 +277,8 @@ async function build() {
             // Build ESM
             ...buildESMConfigurations()
         ];
+
+        await runTests();
 
         log('Building modules');
         log('Please wait');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.44"
 
+"@babel/code-frame@^7.0.0-beta.35":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.54.tgz#0024f96fdf7028a21d68e273afd4e953214a1ead"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.54"
+
 "@babel/generator@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
@@ -41,6 +47,14 @@
 "@babel/highlight@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/highlight@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.54.tgz#155d507358329b8e7068970017c3fd74a9b08584"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
@@ -331,9 +345,13 @@
     react-split-pane "^0.1.77"
     react-treebeard "^2.1.0"
 
-abab@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
+"@types/node@*":
+  version "10.5.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.3.tgz#5bcfaf088ad17894232012877669634c06b20cc5"
+
+abab@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
 abbrev@1:
   version "1.1.0"
@@ -356,11 +374,11 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn-globals@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
+acorn-globals@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
-    acorn "^4.0.4"
+    acorn "^5.0.0"
 
 acorn-jsx@^3.0.0:
   version "3.0.1"
@@ -372,7 +390,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.3, acorn@^4.0.4:
+acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
@@ -387,6 +405,10 @@ acorn@^5.0.1:
 acorn@^5.2.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.0.tgz#1abb587fbf051f94e3de20e6b26ef910b1828298"
+
+acorn@^5.3.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 address@1.0.3, address@^1.0.1:
   version "1.0.3"
@@ -433,6 +455,15 @@ ajv@^5.0.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ajv@^5.1.0:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 ajv@^6.1.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.0.tgz#4c8affdf80887d8f132c9c52ab8a2dc4d0b7b24c"
@@ -458,7 +489,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.3.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.1.0, ansi-escapes@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -482,19 +513,13 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
-  dependencies:
-    color-convert "^1.0.0"
-
 ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
@@ -511,11 +536,18 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+anymatch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
   dependencies:
-    default-require-extensions "^1.0.0"
+    micromatch "^3.1.4"
+    normalize-path "^2.1.1"
+
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  dependencies:
+    default-require-extensions "^2.0.0"
 
 aproba@^1.0.3:
   version "1.1.2"
@@ -678,9 +710,17 @@ ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
 
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@^1.4.0, async@~1.5:
   version "1.5.2"
@@ -736,9 +776,17 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
 aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+aws4@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
 babel-cli@^6.26.0:
   version "6.26.0"
@@ -1040,13 +1088,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-19.0.0.tgz#59323ced99a3a84d359da219ca881074ffc6ce3f"
+babel-jest@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.0.tgz#22c34c392e2176f6a4c367992a7fcff69d2e8557"
   dependencies:
-    babel-core "^6.0.0"
-    babel-plugin-istanbul "^4.0.0"
-    babel-preset-jest "^19.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
 
 babel-loader@^7.1.4:
   version "7.1.4"
@@ -1074,14 +1121,6 @@ babel-plugin-external-helpers@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-istanbul@^4.0.0:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz#18dde84bf3ce329fddf3f4103fae921456d8e587"
-  dependencies:
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.2"
-    test-exclude "^4.1.1"
-
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -1091,9 +1130,9 @@ babel-plugin-istanbul@^4.1.6:
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
 
-babel-plugin-jest-hoist@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-19.0.0.tgz#4ae2a04ea612a6e73651f3fde52c178991304bea"
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-macros@^2.2.0:
   version "2.2.1"
@@ -1685,11 +1724,12 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-jest@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-19.0.0.tgz#22d67201d02324a195811288eb38294bb3cac396"
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
   dependencies:
-    babel-plugin-jest-hoist "^19.0.0"
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-minify@^0.3.0:
   version "0.3.0"
@@ -1827,6 +1867,20 @@ babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
+babel-traverse@^6.0.0, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
 babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
@@ -1841,19 +1895,14 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.26.0:
   version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
     babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
+    esutils "^2.0.2"
     lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
@@ -1864,15 +1913,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
 babylon@7.0.0-beta.31:
   version "7.0.0-beta.31"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
@@ -1881,7 +1921,7 @@ babylon@7.0.0-beta.44:
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
 
-babylon@^6.17.2, babylon@^6.17.4:
+babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -2037,9 +2077,13 @@ brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
-browser-resolve@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+browser-process-hrtime@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -2122,12 +2166,6 @@ browserslist@^3.2.6:
   dependencies:
     caniuse-lite "^1.0.30000835"
     electron-to-chromium "^1.3.45"
-
-bser@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
-  dependencies:
-    node-int64 "^0.4.0"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -2249,6 +2287,12 @@ caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.300008
   version "1.0.30000842"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000842.tgz#7a198e3181a207f4b5749b8f5a1817685bf3d7df"
 
+capture-exit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
+  dependencies:
+    rsvp "^3.3.3"
+
 capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
@@ -2282,7 +2326,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -2301,6 +2345,17 @@ chalk@^2.3.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
@@ -2415,6 +2470,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone-deep@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.3.0.tgz#348c61ae9cdbe0edfe053d91ff4cc521d790ede8"
@@ -2448,12 +2511,6 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
-
-color-convert@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
-  dependencies:
-    color-name "^1.1.1"
 
 color-convert@^1.3.0, color-convert@^1.9.0:
   version "1.9.1"
@@ -2491,9 +2548,19 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+
 colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -2522,6 +2589,10 @@ common-tags@^1.7.2:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+compare-versions@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
 
 component-emitter@^1.2.1:
   version "1.2.1"
@@ -2593,10 +2664,6 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
-content-type-parser@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
-
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
@@ -2605,7 +2672,7 @@ convert-source-map@^1.1.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -2773,7 +2840,7 @@ css-loader@^0.28.11:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2846,9 +2913,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.37 < 0.3.0":
-  version "0.2.37"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
+"cssstyle@>= 0.3.1 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.3.1.tgz#6da9b4cff1bc5d716e6e5fe8e04fcb1b50a49adf"
   dependencies:
     cssom "0.3.x"
 
@@ -2872,6 +2939,14 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.0.0.tgz#24802de4e81c298ea8a9388bb0d8e461c774684f"
+  dependencies:
+    abab "^1.0.4"
+    whatwg-mimetype "^2.0.0"
+    whatwg-url "^6.4.0"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -2882,7 +2957,7 @@ debug@2.6.9, debug@^2.1.2, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
+debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -2906,6 +2981,10 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -2914,11 +2993,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
   dependencies:
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -2999,6 +3078,14 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
+detect-newline@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -3006,9 +3093,9 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
-diff@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -3017,6 +3104,10 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -3042,7 +3133,7 @@ dom-helpers@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -3057,7 +3148,7 @@ domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
 
-domelementtype@1:
+domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
@@ -3065,9 +3156,21 @@ domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
 
+domexception@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 domhandler@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
+  dependencies:
+    domelementtype "1"
+
+domhandler@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   dependencies:
     domelementtype "1"
 
@@ -3080,6 +3183,13 @@ domutils@1.1:
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -3191,11 +3301,57 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-entities@~1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-errno@^0.1.3, errno@^0.1.4:
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+  dependencies:
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.4.0.tgz#c403b81e8eb9953658569e539780964bdc98de62"
+  dependencies:
+    object.assign "^4.1.0"
+    prop-types "^15.6.0"
+
+enzyme-to-json@^3.3.1:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.0.3"
+    has "^1.0.1"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.3"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-inspect "^1.5.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
+
+errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -3323,16 +3479,16 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escodegen@^1.6.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.8.1.tgz#5a5b53af4693110bebb0867aa3430dd3b70a1018"
+escodegen@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
   dependencies:
-    esprima "^2.7.1"
-    estraverse "^1.9.1"
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
   optionalDependencies:
-    source-map "~0.2.0"
+    source-map "~0.6.1"
 
 escope@^3.6.0:
   version "3.6.0"
@@ -3411,17 +3567,17 @@ espree@^3.4.0:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0, esprima@^2.7.1:
+esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.3, esprima@~3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esquery@^1.0.0:
   version "1.0.0"
@@ -3435,10 +3591,6 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
     object-assign "^4.0.1"
-
-estraverse@^1.9.1:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
@@ -3518,6 +3670,10 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -3547,6 +3703,17 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
   dependencies:
     homedir-polyfill "^1.0.1"
+
+expect@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.4.0.tgz#6da4ecc99c1471253e7288338983ad1ebadb60c3"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.2.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 express@^4.16.3:
   version "4.16.3"
@@ -3599,6 +3766,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
 extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+extend@~3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 external-editor@^2.0.4:
   version "2.2.0"
@@ -3660,12 +3831,6 @@ faye-websocket@~0.11.0:
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
   dependencies:
     websocket-driver ">=0.5.1"
-
-fb-watchman@^1.8.0:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
-  dependencies:
-    bser "1.0.2"
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -3839,6 +4004,14 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+form-data@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -3859,6 +4032,12 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -3883,6 +4062,13 @@ fsevents@^1.0.0:
   dependencies:
     nan "^2.3.0"
     node-pre-gyp "^0.6.36"
+
+fsevents@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
+  dependencies:
+    nan "^2.9.2"
+    node-pre-gyp "^0.10.0"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -3909,7 +4095,7 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
-function.prototype.name@^1.1.0:
+function.prototype.name@^1.0.3, function.prototype.name@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
   dependencies:
@@ -3998,7 +4184,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4094,7 +4280,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -4128,12 +4314,23 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -4152,6 +4349,10 @@ has-flag@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -4270,9 +4471,9 @@ html-element-attributes@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.0.tgz#f06ebdfce22de979db82020265cac541fb17d4fc"
 
-html-encoding-sniffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
 
@@ -4317,6 +4518,17 @@ html-webpack-plugin@^2.30.1:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 htmlparser2@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
@@ -4344,6 +4556,14 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -4387,6 +4607,12 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  dependencies:
+    minimatch "^3.0.4"
+
 ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
@@ -4394,6 +4620,13 @@ ignore@^3.2.0:
 immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4551,6 +4784,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.0.2:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4569,9 +4806,9 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-ci@^1.0.9:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
     ci-info "^1.0.0"
 
@@ -4659,6 +4896,10 @@ is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
+is-generator-fn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -4681,6 +4922,10 @@ is-my-json-valid@^2.10.0:
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -4778,6 +5023,14 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+
 is-svg@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
@@ -4837,47 +5090,32 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.0-alpha.1:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.1.10.tgz#f27e5e7125c8de13f6a80661af78f512e5439b2b"
+istanbul-api@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
     async "^2.1.4"
+    compare-versions "^3.1.0"
     fileset "^2.0.2"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-hook "^1.0.7"
-    istanbul-lib-instrument "^1.7.3"
-    istanbul-lib-report "^1.1.1"
-    istanbul-lib-source-maps "^1.2.1"
-    istanbul-reports "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-hook "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-report "^1.1.4"
+    istanbul-lib-source-maps "^1.2.4"
+    istanbul-reports "^1.3.0"
     js-yaml "^3.7.0"
     mkdirp "^0.5.1"
     once "^1.4.0"
-
-istanbul-lib-coverage@^1.0.0, istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
 istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
-istanbul-lib-hook@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz#dd6607f03076578fe7d6f2a630cf143b49bacddc"
+istanbul-lib-hook@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz#f614ec45287b2a8fc4f07f5660af787575601805"
   dependencies:
-    append-transform "^0.4.0"
-
-istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz#925b239163eabdd68cc4048f52c2fa4f899ecfa7"
-  dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.17.4"
-    istanbul-lib-coverage "^1.1.1"
-    semver "^5.3.0"
+    append-transform "^1.0.0"
 
 istanbul-lib-instrument@^1.10.1:
   version "1.10.1"
@@ -4891,226 +5129,318 @@ istanbul-lib-instrument@^1.10.1:
     istanbul-lib-coverage "^1.2.0"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#f0e55f56655ffa34222080b7a0cd4760e1405fc9"
+istanbul-lib-report@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
   dependencies:
-    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-coverage "^1.2.0"
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz#a6fe1acba8ce08eebc638e572e294d267008aa0c"
+istanbul-lib-source-maps@^1.2.4:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz#ffe6be4e7ab86d3603e4290d54990b14506fc9b1"
   dependencies:
-    debug "^2.6.3"
-    istanbul-lib-coverage "^1.1.1"
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.2.0"
     mkdirp "^0.5.1"
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
+istanbul-reports@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-19.0.2.tgz#16c54c84c3270be408e06d2e8af3f3e37a885824"
-
-jest-cli@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-19.0.2.tgz#cc3620b62acac5f2d93a548cb6ef697d4ec85443"
+jest-changed-files@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.0.tgz#f1b304f98c235af5d9a31ec524262c5e4de3c6ff"
   dependencies:
-    ansi-escapes "^1.4.0"
-    callsites "^2.0.0"
-    chalk "^1.1.1"
-    graceful-fs "^4.1.6"
-    is-ci "^1.0.9"
-    istanbul-api "^1.1.0-alpha.1"
-    istanbul-lib-coverage "^1.0.0"
-    istanbul-lib-instrument "^1.1.1"
-    jest-changed-files "^19.0.2"
-    jest-config "^19.0.2"
-    jest-environment-jsdom "^19.0.2"
-    jest-haste-map "^19.0.0"
-    jest-jasmine2 "^19.0.2"
-    jest-message-util "^19.0.0"
-    jest-regex-util "^19.0.0"
-    jest-resolve-dependencies "^19.0.0"
-    jest-runtime "^19.0.2"
-    jest-snapshot "^19.0.2"
-    jest-util "^19.0.2"
+    throat "^4.0.0"
+
+jest-cli@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.4.1.tgz#c1ffd33254caee376990aa2abe2963e0de4ca76b"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.0"
+    jest-config "^23.4.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.4.1"
+    jest-runner "^23.4.1"
+    jest-runtime "^23.4.1"
+    jest-snapshot "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
-    node-notifier "^5.0.1"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
     slash "^1.0.0"
-    string-length "^1.0.1"
-    throat "^3.0.0"
-    which "^1.1.1"
-    worker-farm "^1.3.1"
-    yargs "^6.3.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^11.0.0"
 
-jest-config@^19.0.2:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-19.0.4.tgz#42980211d46417e91ca7abffd086c270234f73fd"
-  dependencies:
-    chalk "^1.1.1"
-    jest-environment-jsdom "^19.0.2"
-    jest-environment-node "^19.0.2"
-    jest-jasmine2 "^19.0.2"
-    jest-regex-util "^19.0.0"
-    jest-resolve "^19.0.2"
-    jest-validate "^19.0.2"
-    pretty-format "^19.0.0"
-
-jest-diff@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-19.0.0.tgz#d1563cfc56c8b60232988fbc05d4d16ed90f063c"
-  dependencies:
-    chalk "^1.1.3"
-    diff "^3.0.0"
-    jest-matcher-utils "^19.0.0"
-    pretty-format "^19.0.0"
-
-jest-environment-jsdom@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-19.0.2.tgz#ceda859c4a4b94ab35e4de7dab54b926f293e4a3"
-  dependencies:
-    jest-mock "^19.0.0"
-    jest-util "^19.0.2"
-    jsdom "^9.11.0"
-
-jest-environment-node@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-19.0.2.tgz#6e84079db87ed21d0c05e1f9669f207b116fe99b"
-  dependencies:
-    jest-mock "^19.0.0"
-    jest-util "^19.0.2"
-
-jest-file-exists@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-file-exists/-/jest-file-exists-19.0.0.tgz#cca2e587a11ec92e24cfeab3f8a94d657f3fceb8"
-
-jest-haste-map@^19.0.0:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-19.0.2.tgz#286484c3a16e86da7872b0877c35dce30c3d6f07"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.6"
-    micromatch "^2.3.11"
-    sane "~1.5.0"
-    worker-farm "^1.3.1"
-
-jest-jasmine2@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-19.0.2.tgz#167991ac825981fb1a800af126e83afcca832c73"
-  dependencies:
-    graceful-fs "^4.1.6"
-    jest-matcher-utils "^19.0.0"
-    jest-matchers "^19.0.0"
-    jest-message-util "^19.0.0"
-    jest-snapshot "^19.0.2"
-
-jest-matcher-utils@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz#5ecd9b63565d2b001f61fbf7ec4c7f537964564d"
-  dependencies:
-    chalk "^1.1.3"
-    pretty-format "^19.0.0"
-
-jest-matchers@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-matchers/-/jest-matchers-19.0.0.tgz#c74ecc6ebfec06f384767ba4d6fa4a42d6755754"
-  dependencies:
-    jest-diff "^19.0.0"
-    jest-matcher-utils "^19.0.0"
-    jest-message-util "^19.0.0"
-    jest-regex-util "^19.0.0"
-
-jest-message-util@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-19.0.0.tgz#721796b89c0e4d761606f9ba8cb828a3b6246416"
-  dependencies:
-    chalk "^1.1.1"
-    micromatch "^2.3.11"
-
-jest-mock@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-19.0.0.tgz#67038641e9607ab2ce08ec4a8cb83aabbc899d01"
-
-jest-regex-util@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-19.0.0.tgz#b7754587112aede1456510bb1f6afe74ef598691"
-
-jest-resolve-dependencies@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-19.0.0.tgz#a741ad1fa094140e64ecf2642a504f834ece22ee"
-  dependencies:
-    jest-file-exists "^19.0.0"
-
-jest-resolve@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-19.0.2.tgz#5793575de4f07aec32f7d7ff0c6c181963eefb3c"
-  dependencies:
-    browser-resolve "^1.11.2"
-    jest-haste-map "^19.0.0"
-    resolve "^1.2.0"
-
-jest-runtime@^19.0.2:
-  version "19.0.4"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-19.0.4.tgz#f167d9f1347752f2027361067926485349fcc245"
+jest-config@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.4.1.tgz#3172fa21f0507d7f8a088ed1dbe4157057f201e9"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^19.0.0"
-    babel-plugin-istanbul "^4.0.0"
-    chalk "^1.1.3"
-    graceful-fs "^4.1.6"
-    jest-config "^19.0.2"
-    jest-file-exists "^19.0.0"
-    jest-haste-map "^19.0.0"
-    jest-regex-util "^19.0.0"
-    jest-resolve "^19.0.2"
-    jest-util "^19.0.2"
-    json-stable-stringify "^1.0.1"
+    babel-jest "^23.4.0"
+    chalk "^2.0.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.4.1"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    pretty-format "^23.2.0"
+
+jest-diff@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.2.0.tgz#9f2cf4b51e12c791550200abc16b47130af1062a"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
+
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
+  dependencies:
+    detect-newline "^2.1.0"
+
+jest-each@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.4.0.tgz#2fa9edd89daa1a4edc9ff9bf6062a36b71345143"
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.2.0"
+
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
+
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+
+jest-get-type@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+
+jest-haste-map@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.4.1.tgz#43a174ba7ac079ae1dd74eaf5a5fe78989474dd2"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
     micromatch "^2.3.11"
+    sane "^2.0.0"
+
+jest-jasmine2@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.4.1.tgz#fa192262430d418e827636e4a98423e5e7ff0fce"
+  dependencies:
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.4.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.2.0"
+    jest-each "^23.4.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.4.1"
+    jest-util "^23.4.0"
+    pretty-format "^23.2.0"
+
+jest-leak-detector@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz#c289d961dc638f14357d4ef96e0431ecc1aa377d"
+  dependencies:
+    pretty-format "^23.2.0"
+
+jest-matcher-utils@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz#4d4981f23213e939e3cedf23dc34c747b5ae1913"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
+
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
+
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
+
+jest-resolve-dependencies@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.1.tgz#a1d85247e2963f8b3859f6b0ec61b741b359378e"
+  dependencies:
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.4.1"
+
+jest-resolve@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.4.1.tgz#7f3c17104732a2c0c940a01256025ed745814982"
+  dependencies:
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
+
+jest-runner@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.4.1.tgz#d41fd1459b95d35d6df685f1468c09e617c8c260"
+  dependencies:
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.1"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.4.1"
+    jest-jasmine2 "^23.4.1"
+    jest-leak-detector "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.4.1"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
+
+jest-runtime@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.4.1.tgz#c1822eba5eb19294debe6b25b2760d0a8c532fd1"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.1"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-snapshot "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
     strip-bom "3.0.0"
-    yargs "^6.3.0"
+    write-file-atomic "^2.1.0"
+    yargs "^11.0.0"
 
-jest-snapshot@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-19.0.2.tgz#9c1b216214f7187c38bfd5c70b1efab16b0ff50b"
-  dependencies:
-    chalk "^1.1.3"
-    jest-diff "^19.0.0"
-    jest-file-exists "^19.0.0"
-    jest-matcher-utils "^19.0.0"
-    jest-util "^19.0.2"
-    natural-compare "^1.4.0"
-    pretty-format "^19.0.0"
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
 
-jest-util@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-19.0.2.tgz#e0a0232a2ab9e6b2b53668bdb3534c2b5977ed41"
+jest-snapshot@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.4.1.tgz#090de9acae927f6a3af3005bda40d912b83e9c96"
   dependencies:
-    chalk "^1.1.1"
-    graceful-fs "^4.1.6"
-    jest-file-exists "^19.0.0"
-    jest-message-util "^19.0.0"
-    jest-mock "^19.0.0"
-    jest-validate "^19.0.2"
-    leven "^2.0.0"
+    babel-traverse "^6.0.0"
+    babel-types "^6.0.0"
+    chalk "^2.0.1"
+    jest-diff "^23.2.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.4.1"
     mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.2.0"
+    semver "^5.5.0"
 
-jest-validate@^19.0.2:
-  version "19.0.2"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.2.tgz#dc534df5f1278d5b63df32b14241d4dbf7244c0c"
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
   dependencies:
-    chalk "^1.1.1"
-    jest-matcher-utils "^19.0.0"
-    leven "^2.0.0"
-    pretty-format "^19.0.0"
+    callsites "^2.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
+    mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
+
+jest-validate@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.4.0.tgz#d96eede01ef03ac909c009e9c8e455197d48c201"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.2.0"
+
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
+  dependencies:
+    merge-stream "^1.0.1"
+
+jest@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.4.1.tgz#39550c72f3237f63ae1b434d8d122cdf6fa007b6"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.4.1"
 
 js-base64@^2.1.9:
   version "2.3.2"
@@ -5152,29 +5482,36 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^9.11.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
+jsdom@^11.5.1:
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.11.0.tgz#df486efad41aee96c59ad7a190e2449c7eb1110e"
   dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
+    abab "^1.0.4"
+    acorn "^5.3.0"
+    acorn-globals "^4.1.0"
     array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
     cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
+    cssstyle ">= 0.3.1 < 0.4.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.0"
+    escodegen "^1.9.0"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.2.0"
+    nwsapi "^2.0.0"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.83.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.3"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^4.0.0"
+    xml-name-validator "^3.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -5273,6 +5610,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kleur@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-1.0.2.tgz#637f126d3cda40a423b1297da88cf753bd04ebdd"
+
 latest-version@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-1.0.1.tgz#72cfc46e3e8d1be651e1ebb54ea9f6ea96f374bb"
@@ -5299,7 +5640,11 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leven@^2.0.0:
+left-pad@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+
+leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
@@ -5453,7 +5798,7 @@ lodash@^4.11.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.17.0, lodash@^4.17.3:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.3:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5580,6 +5925,12 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -5606,7 +5957,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.8:
+micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -5643,6 +5994,10 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.35.0:
+  version "1.35.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
+
 mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
@@ -5654,6 +6009,12 @@ mime-types@~2.1.15:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
     mime-db "~1.30.0"
+
+mime-types@~2.1.17:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mime-types@~2.1.18:
   version "2.1.18"
@@ -5707,6 +6068,19 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+minipass@^2.2.1, minipass@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
+
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -5746,6 +6120,10 @@ moment@^2.21.0:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5777,6 +6155,10 @@ nan@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
 
+nan@^2.9.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
 nanomatch@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
@@ -5806,9 +6188,27 @@ nconf@^0.7.2:
     ini "1.x.x"
     yargs "~3.15.0"
 
+nearley@^2.7.10:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.15.0.tgz#d1ff5406a58064615fe6eafb429cf06fbb1b7eab"
+  dependencies:
+    moo "^0.4.3"
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
+
 needle@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.0.tgz#f14efc69cee1024b72c8b21c7bdf94a731dc12fa"
+  dependencies:
+    debug "^2.1.2"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+needle@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -5879,14 +6279,29 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-notifier@^5.0.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+node-notifier@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
     growly "^1.3.0"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
+
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
     semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
+    tar "^4"
 
 node-pre-gyp@^0.6.36:
   version "0.6.36"
@@ -5906,6 +6321,13 @@ node-status-codes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
+
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -5922,7 +6344,7 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -5940,6 +6362,17 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+npm-bundled@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+
+npm-packlist@^1.1.6:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -5970,11 +6403,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-"nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.1.tgz#7ae9b07b0ea804db7e25f05cb5fe4097d4e4949f"
+nwsapi@^2.0.0:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.7.tgz#6fc54c254621f10cac5225b76e81c74120139b78"
 
-oauth-sign@~0.8.1:
+oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -5994,9 +6427,21 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
 object-keys@^1.0.10, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-keys@^1.0.11:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -6011,6 +6456,15 @@ object.assign@^4.0.4:
     define-properties "^1.1.2"
     function-bind "^1.1.0"
     object-keys "^1.0.10"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
 
 object.entries@^1.0.4:
   version "1.0.4"
@@ -6251,9 +6705,15 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -6325,6 +6785,10 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -6352,6 +6816,10 @@ pkg-dir@^2.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -6672,11 +7140,12 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-19.0.0.tgz#56530d32acb98a3fa4851c4e2b9d37b420684c84"
+pretty-format@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
   dependencies:
-    ansi-styles "^3.0.0"
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 prismjs@^1.9.0:
   version "1.14.0"
@@ -6730,6 +7199,13 @@ promise.prototype.finally@^3.1.0:
   dependencies:
     asap "~2.0.3"
 
+prompts@^0.1.9:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.12.tgz#39dc42de7d2f0ec3e2af76bf40713fcb8726090d"
+  dependencies:
+    kleur "^1.0.0"
+    sisteransi "^0.1.1"
+
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
@@ -6775,6 +7251,10 @@ prr@~1.0.1:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+psl@^1.1.24:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
 
 public-encrypt@^4.0.0:
   version "4.0.0"
@@ -6825,6 +7305,10 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+qs@~6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
@@ -6852,6 +7336,23 @@ radium@^0.19.0:
     exenv "^1.2.1"
     inline-style-prefixer "^2.0.5"
     prop-types "^15.5.8"
+
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -6904,6 +7405,15 @@ rc@^1.1.7:
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
     deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
@@ -7015,6 +7525,10 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
+react-is@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
+
 react-lifecycles-compat@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -7040,6 +7554,15 @@ react-onclickoutside@^6.5.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.0.tgz#997a4d533114c9a0a104913638aa26afc084f75c"
 
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-split-pane@^0.1.77:
   version "0.1.77"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.77.tgz#f0c8cd18d076bbac900248dcf6dbcec02d5340db"
@@ -7053,6 +7576,15 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.1.0.tgz#c8912fc13460f5b0c1ec1114c729d535b52b8073"
   dependencies:
     prop-types "^15.5.4"
+
+react-test-renderer@^16.0.0-0:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.1.tgz#f2fb30c2c7b517db6e5b10ed20bb6b0a7ccd8d70"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.1"
 
 react-textarea-autosize@^5.2.1:
   version "5.2.1"
@@ -7194,6 +7726,12 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
+
+realpath-native@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.1.tgz#07f40a0cce8f8261e2e8b7ebebf5c95965d7b633"
+  dependencies:
+    util.promisify "^1.0.0"
 
 recast@^0.12.6:
   version "0.12.9"
@@ -7366,7 +7904,21 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -7392,6 +7944,31 @@ request@^2.79.0, request@^2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.83.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7420,6 +7997,12 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  dependencies:
+    resolve-from "^3.0.0"
+
 resolve-dir@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -7431,6 +8014,10 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -7439,7 +8026,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.2.0:
+resolve@^1.1.6:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -7542,6 +8129,17 @@ rollup@^0.56.3:
   version "0.56.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.56.3.tgz#7900695531afa1badd3235f285cc4aa0d49ce254"
 
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
+rsvp@^3.3.3:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -7586,6 +8184,10 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -7596,19 +8198,22 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-sane@~1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-1.5.0.tgz#a4adeae764d048621ecb27d5f9ecf513101939f3"
+sane@^2.0.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
   dependencies:
-    anymatch "^1.3.0"
+    anymatch "^2.0.0"
+    capture-exit "^1.2.0"
     exec-sh "^0.2.0"
-    fb-watchman "^1.8.0"
-    minimatch "^3.0.2"
+    fb-watchman "^2.0.0"
+    micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-    watch "~0.10.0"
+    watch "~0.18.0"
+  optionalDependencies:
+    fsevents "^1.2.3"
 
-sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4, sax@~1.2.1:
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -7639,7 +8244,7 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^5.0.1, semver@^5.0.3, semver@^5.1.0:
+semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -7779,13 +8384,17 @@ shelljs@^0.8.1:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shellwords@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -8028,6 +8637,13 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -8046,15 +8662,9 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-source-map@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
-  dependencies:
-    amdefine ">=0.0.4"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -8100,6 +8710,10 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -8110,6 +8724,10 @@ static-extend@^0.1.1:
 "statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 storybook-readme@^3.3.0:
   version "3.3.0"
@@ -8152,11 +8770,18 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
-string-length@^1.0.0, string-length@^1.0.1:
+string-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
   dependencies:
     strip-ansi "^3.0.0"
+
+string-length@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^4.0.0"
 
 string-raw@^1.0.1:
   version "1.0.1"
@@ -8177,7 +8802,7 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^2.1.0:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -8305,7 +8930,7 @@ symbol-observable@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
 
-symbol-tree@^3.2.1:
+symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -8345,22 +8970,24 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tar@^4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
+  dependencies:
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.3"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 tempfile@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
   dependencies:
     os-tmpdir "^1.0.0"
     uuid "^2.0.1"
-
-test-exclude@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
-  dependencies:
-    arrify "^1.0.1"
-    micromatch "^2.3.11"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
 
 test-exclude@^4.2.1:
   version "4.2.1"
@@ -8382,9 +9009,9 @@ then-fs@^2.0.0:
   dependencies:
     promise ">=3.2 <8"
 
-throat@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
+throat@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
 through2@^2.0.0:
   version "2.0.3"
@@ -8479,15 +9106,30 @@ toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0:
+tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+  dependencies:
+    punycode "^1.4.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -8594,6 +9236,10 @@ uid-number@^0.0.6:
 undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
+
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -8730,6 +9376,13 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+util.promisify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
+  dependencies:
+    define-properties "^1.1.2"
+    object.getownpropertydescriptors "^2.0.3"
+
 util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
@@ -8810,6 +9463,12 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -8822,9 +9481,12 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-watch@~0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+watch@~0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
+  dependencies:
+    exec-sh "^0.2.0"
+    minimist "^1.2.0"
 
 watchpack@^1.4.0:
   version "1.4.0"
@@ -8834,13 +9496,9 @@ watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-
-webidl-conversions@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
 webpack-dev-middleware@^1.12.2:
   version "1.12.2"
@@ -8912,16 +9570,27 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
+whatwg-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
+  dependencies:
+    iconv-lite "0.4.19"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
-whatwg-url@^4.3.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
+whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
+
+whatwg-url@^6.4.0, whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -8935,7 +9604,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.1.1, which@^1.2.12:
+which@^1.2.12:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -8944,6 +9613,12 @@ which@^1.1.1, which@^1.2.12:
 which@^1.2.14, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 
@@ -8985,13 +9660,6 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.3.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.4.1.tgz#a438bc993a7a7d133bcb6547c95eca7cff4897d8"
-  dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
-
 worker-farm@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.6.0.tgz#aecc405976fab5a95526180846f0dba288f3a4a0"
@@ -9017,11 +9685,26 @@ write-file-atomic@^1.1.2:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+write-file-atomic@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-4.1.0.tgz#a979b5d7d4da68bf54efe0408967c324869a7289"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
 
 xdg-basedir@^2.0.0:
   version "2.0.0"
@@ -9029,9 +9712,9 @@ xdg-basedir@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 xml2js@^0.4.17:
   version "0.4.19"
@@ -9044,7 +9727,7 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
@@ -9060,6 +9743,10 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
 yargs-parser@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
@@ -9067,17 +9754,34 @@ yargs-parser@^2.4.1:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
 
-yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  dependencies:
-    camelcase "^3.0.0"
-
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^4.3.2:
   version "4.8.1"
@@ -9097,24 +9801,6 @@ yargs@^4.3.2:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
-
-yargs@^6.3.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
-  dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^4.2.0"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
This adds Jest snapshot testing for most all Gumdrops. I've skipped a few of the really basic ones, where prop configuration is non existent or minimal or tested in other parent components. Also added Enzyme so we can write some UI tests going forward 🙌 

I've also added Travis CI to run tests. This will run builds and tests, if either fail it will display a failed check on the PR.

## Changes
 - Adds and configures Jest and Enzyme for snapshot testing
 - Adds `_tests/jestSetup.js` for configuration
 - Adds new npm scripts, `test` and `test:watch`
 - Adds `_tests` with `atoms`, `layout` and `molecules` directories for test files
 - Adds `test` environment to the babel config
 - Adds `.travis.yml` and configured to run the test script on all branches
 - Added the build status badge (for master branch) to the README 
 - and... Lots of snapshots 📷 