### PR TITLE
Enable passing a ref to SearchMultiSelect input

### DIFF
--- a/_stories/molecules/SearchMultiSelect/README.md
+++ b/_stories/molecules/SearchMultiSelect/README.md
@@ -3,10 +3,19 @@ The `<SearchMultiSelect>` is similar to the `<MultiSelect>` component, but it is
 As the name suggests, the `<SearchMultiSelect>` comes with a case insensitive term matching, and a small tag indicator to show you how many options were selected, as well a small balloon where you can quickly see what options you have selected so far.
 
 **Example**:
+
 ```
 state = {
     names: namesList
 };
+
+componentDidMount() {
+    if (this._inputRef.current) {
+        this._inputRef.current.focus();
+    }
+}
+
+_inputRef = React.createRef()
 
 _updateNames = (names) => this.setState({ names });
 
@@ -17,6 +26,7 @@ render() {
         <FormGroup>
            <FormGroupLabel text="names" />
            <SearchMultiSelect
+               inputRef={this._inputRef}
                placeholder="some placeholder text"
                options={ this.state.names }
                update={ this._updateNames }
@@ -35,11 +45,11 @@ render() {
 **Options**:
 The format of the options must be an array of objects that contains at least three properties: `name`, `isSelected`, and `key`.
 
-property   | description
------------|------------
-name       | the text displayed on the dropdown
-isSelected | boolean that determines if the option is selected or not
-key        | uniquely identifies each options (key must be \`unique\`)
+| property   | description                                               |
+| ---------- | --------------------------------------------------------- |
+| name       | the text displayed on the dropdown                        |
+| isSelected | boolean that determines if the option is selected or not  |
+| key        | uniquely identifies each options (key must be \`unique\`) |
 
 ```
 [
@@ -52,30 +62,30 @@ key        | uniquely identifies each options (key must be \`unique\`)
 ]
 ```
 
-
 **Props**:
 
-prop name   | description
-------------|------------
-options     | list of options {array of objects}
-update      | callback that returns the latest change on options {function}
-onChange    | callback that returns the current input value, useful for autocompletion {function}
-filter      | optional custom function to filter elements, the arguments passed to it are current options {Array} and search term {String}, must return an array with the indexes of the options to display in the dropdown {function}
-context     | for now, this only affects the color of the Tag elements. (For not it only affects the tags, but it will support the input itself soon).
-placeholder | placeholder text {String}
-size        | size for the input, only md or sm are allowed {String}
-searchKeys  | flag to signal if the search should also match against object keys {Boolean}
-multiTerm   | flag to signal if the search should match against multiple terms {Boolean}
-termDivider | string or regexp used to divide the search term, defaults to /[ ,]+/ (empty space and comma) {String OR RegExp}
+| prop name   | description                                                                                                                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| options     | list of options {array of objects}                                                                                                                                                                                       |
+| update      | callback that returns the latest change on options {function}                                                                                                                                                            |
+| onChange    | callback that returns the current input value, useful for autocompletion {function}                                                                                                                                      |
+| filter      | optional custom function to filter elements, the arguments passed to it are current options {Array} and search term {String}, must return an array with the indexes of the options to display in the dropdown {function} |
+| context     | for now, this only affects the color of the Tag elements. (For not it only affects the tags, but it will support the input itself soon).                                                                                 |
+| placeholder | placeholder text {String}                                                                                                                                                                                                |
+| size        | size for the input, only md or sm are allowed {String}                                                                                                                                                                   |
+| searchKeys  | flag to signal if the search should also match against object keys {Boolean}                                                                                                                                             |
+| multiTerm   | flag to signal if the search should match against multiple terms {Boolean}                                                                                                                                               |
+| termDivider | string or regexp used to divide the search term, defaults to /[ ,]+/ (empty space and comma) {String OR RegExp}                                                                                                          |
+| inputRef    | ref applied to the input, useful for setting focus {function                                                                                                                                                             | object} |
 
 **Context list**:
 'primary', 'secondary', 'success', 'warning', 'info', 'danger', 'white'
 
 **Keybindings**:
 
-key   | description
-------|------------
-enter | toggles the currently highlighted option
-up    | highlights the previous options
-down  | highlights the next option
-esc   | closes the dropdown
+| key   | description                              |
+| ----- | ---------------------------------------- |
+| enter | toggles the currently highlighted option |
+| up    | highlights the previous options          |
+| down  | highlights the next option               |
+| esc   | closes the dropdown                      |

--- a/_stories/molecules/SearchMultiSelect/README.md
+++ b/_stories/molecules/SearchMultiSelect/README.md
@@ -76,7 +76,7 @@ The format of the options must be an array of objects that contains at least thr
 | searchKeys  | flag to signal if the search should also match against object keys {Boolean}                                                                                                                                             |
 | multiTerm   | flag to signal if the search should match against multiple terms {Boolean}                                                                                                                                               |
 | termDivider | string or regexp used to divide the search term, defaults to /[ ,]+/ (empty space and comma) {String OR RegExp}                                                                                                          |
-| inputRef    | ref applied to the input, useful for setting focus {function                                                                                                                                                             | object} |
+| inputRef    | ref applied to the input, useful for setting focus {function OR object}                                                                                                                                                  |
 
 **Context list**:
 'primary', 'secondary', 'success', 'warning', 'info', 'danger', 'white'

--- a/_stories/molecules/SearchMultiSelect/index.js
+++ b/_stories/molecules/SearchMultiSelect/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { selectV2 as select, text, boolean } from '@storybook/addon-knobs';
+import { selectV2 as select, text, boolean, button } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import readme from './README.md';
@@ -13,10 +13,14 @@ class TestSearchMultiSelect extends React.Component {
     };
 
     componentDidMount() {
+        this._setFocus();
+    }
+
+    _setFocus = () => {
         if (this._inputRef.current) {
             this._inputRef.current.focus();
         }
-    }
+    };
 
     _inputRef = React.createRef();
 
@@ -31,6 +35,7 @@ class TestSearchMultiSelect extends React.Component {
         return (
             <FormGroup>
                 <FormGroupLabel text="names" />
+                {button('Set focus', this._setFocus)}
                 <SearchMultiSelect
                     inputRef={this._inputRef}
                     placeholder={text('Placeholder', 'My placeholder')}

--- a/_stories/molecules/SearchMultiSelect/index.js
+++ b/_stories/molecules/SearchMultiSelect/index.js
@@ -12,6 +12,14 @@ class TestSearchMultiSelect extends React.Component {
         names: namesList
     };
 
+    componentDidMount() {
+        if (this._inputRef.current) {
+            this._inputRef.current.focus();
+        }
+    }
+
+    _inputRef = React.createRef();
+
     _updateNames = names => {
         this.setState({ names });
         action('SearchMultiSelect Updated')(names);
@@ -24,6 +32,7 @@ class TestSearchMultiSelect extends React.Component {
             <FormGroup>
                 <FormGroupLabel text="names" />
                 <SearchMultiSelect
+                    inputRef={this._inputRef}
                     placeholder={text('Placeholder', 'My placeholder')}
                     options={this.state.names}
                     update={this._updateNames}
@@ -39,12 +48,7 @@ class TestSearchMultiSelect extends React.Component {
     }
 }
 
-const component = () => <TestSearchMultiSelect />;
-
-const options = {
-    inline: true,
-    propTables: [SearchMultiSelect]
-};
+const component = () => <TestSearchMultiSelect />; //eslint-disable-line react/no-multi-comp
 
 // Props data
 const namesList = [

--- a/components/molecules/SearchMultiSelect.jsx
+++ b/components/molecules/SearchMultiSelect.jsx
@@ -24,7 +24,7 @@ class SearchMultiSelect extends Component {
         window.addEventListener('click', this._closeOnClickOutside);
     }
 
-    componentWillReceiveProps({ options, searchKeys, multiTerm, termDivider, filter }) {
+    UNSAFE_componentWillReceiveProps({ options, searchKeys, multiTerm, termDivider, filter }) {
         const old = this.props;
         if (!arraysEqual(options, old.options)) {
             const searchConfig = { searchKeys, multiTerm, termDivider };
@@ -33,7 +33,7 @@ class SearchMultiSelect extends Component {
         }
     }
 
-    componentWillUpdate(_, { searchTerm }) {
+    UNSAFE_componentWillUpdate(_, { searchTerm }) {
         const { options, searchKeys, multiTerm, termDivider, filter } = this.props;
         const searchConfig = { searchKeys, multiTerm, termDivider };
         const { searchTerm: oldTerm, currentIndex, isOpen } = this.state;
@@ -169,7 +169,7 @@ class SearchMultiSelect extends Component {
 
     render() {
         const { isOpen, isTagsOpen, currentIndex, matchingIndexes } = this.state;
-        const { options, context, placeholder, size } = this.props;
+        const { inputRef, options, context, placeholder, size } = this.props;
 
         const numberSelected = options.filter(o => o.isSelected).length;
 
@@ -200,6 +200,7 @@ class SearchMultiSelect extends Component {
                         />
                     )}
                     <input
+                        ref={inputRef}
                         onFocus={this._openSelect}
                         onClick={this._openSelect}
                         onChange={this._updateSearchTerm}
@@ -315,7 +316,8 @@ SearchMultiSelect.propTypes = {
     size: PropTypes.oneOf(['sm', 'md']),
     searchKeys: PropTypes.bool,
     multiTerm: PropTypes.bool,
-    termDivider: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
+    termDivider: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)]),
+    inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
 };
 
 export default SearchMultiSelect;


### PR DESCRIPTION
This is a simple PR that allows passing a ref to be used in the SearchMultiSelect input, this is helpful to auto focus on the component after rendering.