### PR TITLE
Feature/27 add groupings to multi select component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,7 @@
         "curly": [1, "multi-line"],
         "keyword-spacing": [1, {}],
         "space-before-blocks": [1, "always"],
-        "wrap-iife": 1,
+        "wrap-iife": 0,
         "one-var": 0,
         "vars-on-top": 0,
         "no-empty": [1, { "allowEmptyCatch": true }],

--- a/_stories/molecules/MultiSelect/README.md
+++ b/_stories/molecules/MultiSelect/README.md
@@ -1,62 +1,136 @@
+# MultiSelect
+
 The `<MultiSelect>` component can be used when you need a select component to support multiple options simultaneously.
 
-The state on the multi-select is handed by the parent component, the callback passed into should also take care of updating the dropdown options.
+The state of the multi-select is handled by the parent component. An `onChange` prop handler is provided that will be called with the updated list of options whenever there's a change.
 
-**NOTE**: This is a controlled component, so don't forget to pass the updated props to `MultiSelect` to see the changes.
+Multi-select also supports nested options [See Nested Options](#nested-options). When a parent option is selected, all children will be selected. If all children are selected, the parent will be selected too.
 
-**Example**:
-```
-state {
-    options: [ { name: 'Some Name', value: 'some_value', selected: false}, ... ]
+**NOTE**: This is a controlled component, so don't forget to pass the updated props to `MultiSelect` to see the changes. [See Example](#example)
+
+## Props
+
+| Prop        | Type       | Required | Description                                                                             |
+| ----------- | ---------- | -------- | --------------------------------------------------------------------------------------- |
+| options     | `Array`    | `True`   | The select options that will make up the dropdown menu. [See Options](#options)         |
+| onChange    | `Function` |          | Change handler will be called with the updated list of `option` based on user selection |
+| placeholder | `String`   |          | Text that appears before any options are selected                                       |
+| size        | `String`   |          | Size that determines the scale of the UI elements                                       |
+| className   | `String`   |          | Additional classes to apply to the outermost element                                    |
+
+## Options
+
+Options determine the construction of the multi-select menu. It takes an `Array` of `Objects` with the following shape:
+
+```javascript
+{
+    name: 'John', // label displayed next to the checkbox
+    value: 'john', // value associated with the option
+    selected: true // current selected state
 }
-const handleMultiselectChange = (index, value, selected) => {
-    // Update your options here
-    const newOptions = ...;
-    this.setState({ options: newOptions });
-};
-return(
-    <MultiSelect
-       placeholder="Select an option"
-       options={ this.state.options }
-       callback= { this.handleMultiselectChange }
-    />
-)
 ```
 
-*Options format*:
-```
-[
+Here's an example of a possible set of options:
+
+```javascript
+const people = [
     {
-        name: 'Option 1',
-        value: 'option_1',
+        name: 'John',
+        value: 'john',
+        selected: true
+    },
+    {
+        name: 'Sam',
+        value: 'sam',
         selected: false
     },
     {
-        name: 'Option 2',
-        value: 'option_2',
+        name: 'Jane',
+        value: 'jane',
         selected: true
     },
-    ...
-]
+    {
+        name: 'Sara',
+        value: 'sara',
+        selected: false
+    }
+];
 ```
 
-The callback receives 3 paramenters:
-- `index` {Number} position on the array of the option changed
-- `value` {String} of the option change
-- `selected`{Boolean} new value of the option. \n
+### Nested Options
 
+You may also have nested options. Here's an example:
 
-Therefore, your callback should look like this:
-```
-function callback(index, value, selected){
-     ...
-}
+```javascript
+const pets = [
+    {
+        name: 'All Pets',
+        value: 0,
+        selected: false
+    },
+    {
+        name: 'Dogs',
+        value: 1,
+        selected: false,
+        options: [
+            {
+                name: 'Lassie',
+                value: 1,
+                selected: true
+            },
+            {
+                name: 'Snoopy',
+                value: 2,
+                selected: true
+            }
+        ]
+    },
+    {
+        name: 'Cats',
+        value: 'cats',
+        selected: false,
+        options: [
+            {
+                name: 'Grumpy Cat',
+                value: 1,
+                selected: true
+            },
+            {
+                name: 'Lil Bub',
+                value: 2,
+                selected: true
+            }
+        ]
+    }
+];
 ```
 
-If you want to add an option that "checks" all the other ones. You can create a new option with a value of `SELECT_ALL`, and in your callback handler you can check for that option:
-```
-if (value === 'SELECT_ALL' && selected) {
-    // Checks all the options as true
-    return someOptions.map( o => ({ ...o, selected: true }));
+## Example
+
+```javascript
+import MultiSelect from 'gumdrops/MultiSelect';
+import pets from './pets';
+
+class MyComponent extends Component {
+    state = {
+        options: pets
+    };
+
+    handleChange = newOptions => {
+        this.setState({
+            options: newOptions
+        });
+    };
+
+    render() {
+        return (
+            <MultiSelect
+                className="cool-options"
+                onChange={this.handleChange}
+                options={this.state.options}
+                size="md"
+            />
+        );
+    }
 }
 ```

--- a/_stories/molecules/MultiSelect/index.js
+++ b/_stories/molecules/MultiSelect/index.js
@@ -1,18 +1,101 @@
 import React, { Component } from 'react';
 import { text } from '@storybook/addon-knobs';
 import { optionalSelect } from '../../../components/utils/optionalSelect';
-import { action } from '@storybook/addon-actions';
+import { selectV2 as select } from '@storybook/addon-knobs';
+// import { action } from '@storybook/addon-actions';
 
 import readme from './README.md';
 import MultiSelect from '../../../components/molecules/MultiSelect';
 
-const options = Array(10)
-    .fill({})
-    .map((o, i) => ({
-        name: `Option ${i + 1}`,
-        value: i,
+const optionsA = [
+    {
+        name: 'Lassie',
+        value: 1,
+        selected: true
+    },
+    {
+        name: 'Snoopy',
+        value: 2,
+        selected: true
+    },
+    {
+        name: 'Toto',
+        value: 3,
         selected: false
-    }));
+    },
+    {
+        name: 'Brian Griffin',
+        value: 3,
+        selected: false
+    }
+];
+
+const optionsB = [
+    {
+        name: 'All Pets',
+        value: 0,
+        selected: false
+    },
+    {
+        name: 'Dogs',
+        value: 1,
+        selected: false,
+        options: [
+            {
+                name: 'Lassie',
+                value: 1,
+                selected: true
+            },
+            {
+                name: 'Snoopy',
+                value: 2,
+                selected: true
+            },
+            {
+                name: 'Toto',
+                value: 3,
+                selected: false
+            },
+            {
+                name: 'Brian Griffin',
+                value: 3,
+                selected: false
+            }
+        ]
+    },
+    {
+        name: 'Cats',
+        value: 'cats',
+        selected: false,
+        options: [
+            {
+                name: 'Grumpy Cat',
+                value: 1,
+                selected: true
+            },
+            {
+                name: 'Lil Bub',
+                value: 2,
+                selected: true
+            },
+            {
+                name: 'Hello Kitty',
+                value: 3,
+                selected: false
+            }
+        ]
+    }
+];
+
+const configSelect = {
+    Normal: 'A',
+    Nested: 'B'
+};
+
+const options = {
+    A: optionsA,
+    B: optionsB
+};
 
 const sizeOptions = {
     sm: 'sm',
@@ -22,17 +105,18 @@ const sizeOptions = {
 
 class MultiSelectOptions extends Component {
     state = {
-        options
+        options: this.props.options
     };
 
-    handleCallback = (index, value, selected) => {
-        const options = this.state.options.map((o, i) => ({
-            ...o,
-            selected: i === index ? selected : o.selected
-        }));
+    static getDerivedStateFromProps(props) {
+        return {
+            options: props.options
+        };
+    }
 
+    handleChange = newOptions => {
         this.setState({
-            options
+            options: newOptions
         });
     };
 
@@ -41,7 +125,7 @@ class MultiSelectOptions extends Component {
             <MultiSelect
                 placeholder={text('Placeholder', 'Select an option')}
                 size={optionalSelect('Size', sizeOptions, '')}
-                callback={this.handleCallback}
+                onChange={this.handleChange}
                 options={this.state.options}
                 className={text('className', '')}
             />
@@ -49,6 +133,9 @@ class MultiSelectOptions extends Component {
     }
 }
 
-const component = () => <MultiSelectOptions />;
+const component = () => {
+    const selectedOptions = select('Options Config', configSelect, 'A');
+    return <MultiSelectOptions options={options[selectedOptions]} />;
+};
 
 export default [readme, component];

--- a/_tests/molecules/MultiSelect.test.js
+++ b/_tests/molecules/MultiSelect.test.js
@@ -2,14 +2,33 @@
 import React from 'react';
 import MultiSelect from '../../components/molecules/MultiSelect';
 
+const options = [
+    { name: 'All Pets', value: 0, selected: false },
+    {
+        name: 'Dogs',
+        value: 1,
+        selected: false,
+        options: [
+            { name: 'Lassie', value: 1, selected: true },
+            { name: 'Snoopy', value: 2, selected: true },
+            { name: 'Toto', value: 3, selected: false },
+            { name: 'Brian Griffin', value: 3, selected: false }
+        ]
+    },
+    {
+        name: 'Cats',
+        value: 'cats',
+        selected: false,
+        options: [
+            { name: 'Grumpy Cat', value: 1, selected: true },
+            { name: 'Lil Bub', value: 2, selected: true },
+            { name: 'Hello Kitty', value: 3, selected: false }
+        ]
+    }
+];
+
 const defaultProps = {
-    options: [
-        {
-            name: 'Name',
-            value: 10,
-            selected: true
-        }
-    ],
+    options,
     callback: () => {},
     placeholder: 'placeholder',
     size: 'xs',
@@ -20,5 +39,18 @@ describe('Expect <MultiSelect>', () => {
     it('to render', () => {
         const wrapper = mount(<MultiSelect {...defaultProps} />);
         expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to open and close', () => {
+        const wrapper = shallow(<MultiSelect {...defaultProps} />);
+        const menuBtn = wrapper.find('button[name="multiselectMenu"]');
+        expect(wrapper.state().isOpen).toEqual(false);
+        // open
+        menuBtn.simulate('click');
+        expect(wrapper.state().isOpen).toEqual(true);
+        expect(wrapper).toMatchSnapshot();
+        // close
+        menuBtn.simulate('click');
+        expect(wrapper.state().isOpen).toEqual(false);
     });
 });

--- a/_tests/molecules/MultiSelectMenuItem.test.js
+++ b/_tests/molecules/MultiSelectMenuItem.test.js
@@ -1,0 +1,73 @@
+/* globals mount */
+import React from 'react';
+import MultiSelectMenuItem from '../../components/molecules/MultiSelectMenuItem';
+
+const subOptions = [
+    { name: 'Lassie', value: 1, selected: false },
+    { name: 'Snoopy', value: 2, selected: false },
+    { name: 'Toto', value: 3, selected: false },
+    { name: 'Brian Griffin', value: 3, selected: false }
+];
+
+const defaultProps = {
+    callback: () => {},
+    index: 1,
+    isActive: false,
+    name: 'Foo',
+    onChange: () => {},
+    onClick: () => {},
+    selected: false,
+    size: 'xs',
+    value: 0
+};
+
+describe('Expect <MultiSelectMenuItem>', () => {
+    it('to render', () => {
+        const wrapper = mount(<MultiSelectMenuItem {...defaultProps} />);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to call the onChange prop handler when options change', () => {
+        const props = {
+            ...defaultProps,
+            onChange: jest.fn(),
+            callback: jest.fn()
+        };
+        const wrapper = mount(<MultiSelectMenuItem {...props} />);
+        wrapper
+            .find('Checkbox input[type="checkbox"]')
+            .first()
+            .simulate('change');
+
+        expect(props.onChange).toBeCalledWith({
+            index: props.index,
+            selected: !props.selected,
+            value: props.value
+        });
+
+        expect(props.callback).toBeCalledWith(props.index, props.value, !props.selected); // deprecated
+    });
+
+    it('to call the onChange prop handler with sub options', () => {
+        const props = {
+            ...defaultProps,
+            subOptions,
+            onChange: jest.fn(),
+            callback: jest.fn()
+        };
+        const wrapper = mount(<MultiSelectMenuItem {...props} />);
+        wrapper
+            .find('Checkbox input[type="checkbox"]')
+            .first()
+            .simulate('change');
+
+        expect(props.onChange).toBeCalledWith({
+            index: props.index,
+            selected: !props.selected,
+            value: props.value,
+            options: subOptions
+        });
+
+        expect(props.callback).toBeCalledWith(props.index, props.value, !props.selected); // deprecated
+    });
+});

--- a/_tests/molecules/__snapshots__/MultiSelect.test.js.snap
+++ b/_tests/molecules/__snapshots__/MultiSelect.test.js.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Expect <MultiSelect> to open and close 1`] = `
+<div
+  className="gds-multi-select custom-class gds-multi-select--xs gds-button-dropdown--active"
+  placeholder="placeholder"
+>
+  <button
+    aria-controls="MultiSelect_region_TXVsdGlTZWxlY3Q=1"
+    aria-expanded={true}
+    aria-pressed={true}
+    className="gds-multi-select__button gds-multi-select__button--xs"
+    id="MultiSelect_label_TXVsdGlTZWxlY3Q=1"
+    name="multiselectMenu"
+    onClick={[Function]}
+    tabIndex={0}
+    type="button"
+  >
+    <div
+      className="-ellipsis"
+    >
+      Lassie, Snoopy, Grumpy Cat, Lil Bub
+    </div>
+  </button>
+  <ul
+    aria-hidden={false}
+    aria-labelledby="MultiSelect_label_TXVsdGlTZWxlY3Q=1"
+    className="gds-multi-select__menu"
+    id="MultiSelect_region_TXVsdGlTZWxlY3Q=1"
+    role="region"
+  >
+    <MultiSelectMenuItem
+      callback={[Function]}
+      index={0}
+      key="menu-item-0"
+      name="All Pets"
+      onChange={[Function]}
+      selected={false}
+      size="xs"
+      value={0}
+    />
+    <MultiSelectSubMenu
+      index={1}
+      key="menu-item-1"
+      name="Dogs"
+      onChange={[Function]}
+      onSubChange={[Function]}
+      options={
+        Array [
+          Object {
+            "name": "Lassie",
+            "selected": true,
+            "value": 1,
+          },
+          Object {
+            "name": "Snoopy",
+            "selected": true,
+            "value": 2,
+          },
+          Object {
+            "name": "Toto",
+            "selected": false,
+            "value": 3,
+          },
+          Object {
+            "name": "Brian Griffin",
+            "selected": false,
+            "value": 3,
+          },
+        ]
+      }
+      selected={false}
+      size="xs"
+      value={1}
+    />
+    <MultiSelectSubMenu
+      index={2}
+      key="menu-item-2"
+      name="Cats"
+      onChange={[Function]}
+      onSubChange={[Function]}
+      options={
+        Array [
+          Object {
+            "name": "Grumpy Cat",
+            "selected": true,
+            "value": 1,
+          },
+          Object {
+            "name": "Lil Bub",
+            "selected": true,
+            "value": 2,
+          },
+          Object {
+            "name": "Hello Kitty",
+            "selected": false,
+            "value": 3,
+          },
+        ]
+      }
+      selected={false}
+      size="xs"
+      value="cats"
+    />
+  </ul>
+</div>
+`;
+
 exports[`Expect <MultiSelect> to render 1`] = `
 <MultiSelect
   callback={[Function]}
@@ -7,9 +113,58 @@ exports[`Expect <MultiSelect> to render 1`] = `
   options={
     Array [
       Object {
-        "name": "Name",
-        "selected": true,
-        "value": 10,
+        "name": "All Pets",
+        "selected": false,
+        "value": 0,
+      },
+      Object {
+        "name": "Dogs",
+        "options": Array [
+          Object {
+            "name": "Lassie",
+            "selected": true,
+            "value": 1,
+          },
+          Object {
+            "name": "Snoopy",
+            "selected": true,
+            "value": 2,
+          },
+          Object {
+            "name": "Toto",
+            "selected": false,
+            "value": 3,
+          },
+          Object {
+            "name": "Brian Griffin",
+            "selected": false,
+            "value": 3,
+          },
+        ],
+        "selected": false,
+        "value": 1,
+      },
+      Object {
+        "name": "Cats",
+        "options": Array [
+          Object {
+            "name": "Grumpy Cat",
+            "selected": true,
+            "value": 1,
+          },
+          Object {
+            "name": "Lil Bub",
+            "selected": true,
+            "value": 2,
+          },
+          Object {
+            "name": "Hello Kitty",
+            "selected": false,
+            "value": 3,
+          },
+        ],
+        "selected": false,
+        "value": "cats",
       },
     ]
   }
@@ -18,6 +173,7 @@ exports[`Expect <MultiSelect> to render 1`] = `
 >
   <div
     className="gds-multi-select custom-class gds-multi-select--xs"
+    placeholder="placeholder"
   >
     <button
       aria-controls="MultiSelect_region_TXVsdGlTZWxlY3Q=0"
@@ -25,6 +181,7 @@ exports[`Expect <MultiSelect> to render 1`] = `
       aria-pressed={false}
       className="gds-multi-select__button gds-multi-select__button--xs"
       id="MultiSelect_label_TXVsdGlTZWxlY3Q=0"
+      name="multiselectMenu"
       onClick={[Function]}
       tabIndex={0}
       type="button"
@@ -32,7 +189,7 @@ exports[`Expect <MultiSelect> to render 1`] = `
       <div
         className="-ellipsis"
       >
-        Name
+        Lassie, Snoopy, Grumpy Cat, Lil Bub
       </div>
     </button>
     <ul
@@ -42,43 +199,544 @@ exports[`Expect <MultiSelect> to render 1`] = `
       id="MultiSelect_region_TXVsdGlTZWxlY3Q=0"
       role="region"
     >
-      <li
-        className="gds-multi-select__menu-item"
-        key="item-0"
+      <MultiSelectMenuItem
+        callback={[Function]}
+        index={0}
+        key="menu-item-0"
+        name="All Pets"
+        onChange={[Function]}
+        selected={false}
+        size="xs"
+        value={0}
       >
-        <div
-          className="gds-multi-select__menu-link"
+        <li
+          className="gds-multi-select__menu-item"
         >
           <div
-            className="gds-form-group gds-multi-select__option"
+            className="gds-multi-select__menu-link"
           >
-            <Checkbox
-              checked={true}
-              label="Name"
-              onChange={[Function]}
+            <div
+              className="gds-form-group gds-multi-select__option"
+              onClick={[Function]}
+            >
+              <Checkbox
+                checked={false}
+                label="All Pets"
+                onChange={[Function]}
+                size="xs"
+              >
+                <div
+                  className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                >
+                  <label
+                    className="gds-form-group__checkbox-label"
+                  >
+                    <input
+                      checked={false}
+                      className="gds-form-group__checkbox-input"
+                      onChange={[Function]}
+                      type="checkbox"
+                    />
+                    <span
+                      className="gds-form-group__checkbox-indicator"
+                    />
+                    All Pets
+                  </label>
+                </div>
+              </Checkbox>
+            </div>
+          </div>
+        </li>
+      </MultiSelectMenuItem>
+      <MultiSelectSubMenu
+        index={1}
+        key="menu-item-1"
+        name="Dogs"
+        onChange={[Function]}
+        onSubChange={[Function]}
+        options={
+          Array [
+            Object {
+              "name": "Lassie",
+              "selected": true,
+              "value": 1,
+            },
+            Object {
+              "name": "Snoopy",
+              "selected": true,
+              "value": 2,
+            },
+            Object {
+              "name": "Toto",
+              "selected": false,
+              "value": 3,
+            },
+            Object {
+              "name": "Brian Griffin",
+              "selected": false,
+              "value": 3,
+            },
+          ]
+        }
+        selected={false}
+        size="xs"
+        value={1}
+      >
+        <MultiSelectMenuItem
+          index={1}
+          isActive={true}
+          name="Dogs"
+          onChange={[Function]}
+          onClick={[Function]}
+          selected={false}
+          size="xs"
+          subOptions={
+            Array [
+              Object {
+                "name": "Lassie",
+                "selected": true,
+                "value": 1,
+              },
+              Object {
+                "name": "Snoopy",
+                "selected": true,
+                "value": 2,
+              },
+              Object {
+                "name": "Toto",
+                "selected": false,
+                "value": 3,
+              },
+              Object {
+                "name": "Brian Griffin",
+                "selected": false,
+                "value": 3,
+              },
+            ]
+          }
+          value={1}
+        >
+          <li
+            className="gds-multi-select__menu-item"
+            onClick={[Function]}
+          >
+            <div
+              className="gds-multi-select__menu-link gds-multi-select__menu-link--collapsable gds-multi-select__menu-link--active"
             >
               <div
-                className="gds-form-group__checkbox"
+                className="gds-form-group gds-multi-select__option"
+                onClick={[Function]}
               >
-                <label
-                  className="gds-form-group__checkbox-label"
+                <Checkbox
+                  checked={false}
+                  label="Dogs"
+                  onChange={[Function]}
+                  size="xs"
                 >
-                  <input
-                    checked={true}
-                    className="gds-form-group__checkbox-input"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="gds-form-group__checkbox-indicator"
-                  />
-                  Name
-                </label>
+                  <div
+                    className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                  >
+                    <label
+                      className="gds-form-group__checkbox-label"
+                    >
+                      <input
+                        checked={false}
+                        className="gds-form-group__checkbox-input"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="gds-form-group__checkbox-indicator"
+                      />
+                      Dogs
+                    </label>
+                  </div>
+                </Checkbox>
               </div>
-            </Checkbox>
-          </div>
-        </div>
-      </li>
+              <ul
+                className="gds-multi-select__sub-menu"
+              >
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-0"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={true}
+                        label="Lassie"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={true}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Lassie
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-1"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={true}
+                        label="Snoopy"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={true}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Snoopy
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-2"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={false}
+                        label="Toto"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={false}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Toto
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-3"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={false}
+                        label="Brian Griffin"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={false}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Brian Griffin
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </MultiSelectMenuItem>
+      </MultiSelectSubMenu>
+      <MultiSelectSubMenu
+        index={2}
+        key="menu-item-2"
+        name="Cats"
+        onChange={[Function]}
+        onSubChange={[Function]}
+        options={
+          Array [
+            Object {
+              "name": "Grumpy Cat",
+              "selected": true,
+              "value": 1,
+            },
+            Object {
+              "name": "Lil Bub",
+              "selected": true,
+              "value": 2,
+            },
+            Object {
+              "name": "Hello Kitty",
+              "selected": false,
+              "value": 3,
+            },
+          ]
+        }
+        selected={false}
+        size="xs"
+        value="cats"
+      >
+        <MultiSelectMenuItem
+          index={2}
+          isActive={true}
+          name="Cats"
+          onChange={[Function]}
+          onClick={[Function]}
+          selected={false}
+          size="xs"
+          subOptions={
+            Array [
+              Object {
+                "name": "Grumpy Cat",
+                "selected": true,
+                "value": 1,
+              },
+              Object {
+                "name": "Lil Bub",
+                "selected": true,
+                "value": 2,
+              },
+              Object {
+                "name": "Hello Kitty",
+                "selected": false,
+                "value": 3,
+              },
+            ]
+          }
+          value="cats"
+        >
+          <li
+            className="gds-multi-select__menu-item"
+            onClick={[Function]}
+          >
+            <div
+              className="gds-multi-select__menu-link gds-multi-select__menu-link--collapsable gds-multi-select__menu-link--active"
+            >
+              <div
+                className="gds-form-group gds-multi-select__option"
+                onClick={[Function]}
+              >
+                <Checkbox
+                  checked={false}
+                  label="Cats"
+                  onChange={[Function]}
+                  size="xs"
+                >
+                  <div
+                    className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                  >
+                    <label
+                      className="gds-form-group__checkbox-label"
+                    >
+                      <input
+                        checked={false}
+                        className="gds-form-group__checkbox-input"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="gds-form-group__checkbox-indicator"
+                      />
+                      Cats
+                    </label>
+                  </div>
+                </Checkbox>
+              </div>
+              <ul
+                className="gds-multi-select__sub-menu"
+              >
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-0"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={true}
+                        label="Grumpy Cat"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={true}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Grumpy Cat
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-1"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={true}
+                        label="Lil Bub"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={true}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Lil Bub
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+                <li
+                  className="gds-multi-select__menu-item"
+                  key="item-2"
+                  onClick={[Function]}
+                >
+                  <div
+                    className="gds-multi-select__menu-link"
+                  >
+                    <div
+                      className="gds-form-group gds-multi-select__option"
+                    >
+                      <Checkbox
+                        checked={false}
+                        label="Hello Kitty"
+                        onChange={[Function]}
+                        size="xs"
+                      >
+                        <div
+                          className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+                        >
+                          <label
+                            className="gds-form-group__checkbox-label"
+                          >
+                            <input
+                              checked={false}
+                              className="gds-form-group__checkbox-input"
+                              onChange={[Function]}
+                              type="checkbox"
+                            />
+                            <span
+                              className="gds-form-group__checkbox-indicator"
+                            />
+                            Hello Kitty
+                          </label>
+                        </div>
+                      </Checkbox>
+                    </div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </MultiSelectMenuItem>
+      </MultiSelectSubMenu>
     </ul>
   </div>
 </MultiSelect>

--- a/_tests/molecules/__snapshots__/MultiSelectMenuItem.test.js.snap
+++ b/_tests/molecules/__snapshots__/MultiSelectMenuItem.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expect <MultiSelectMenuItem> to render 1`] = `
+<MultiSelectMenuItem
+  callback={[Function]}
+  index={1}
+  isActive={false}
+  name="Foo"
+  onChange={[Function]}
+  onClick={[Function]}
+  selected={false}
+  size="xs"
+  value={0}
+>
+  <li
+    className="gds-multi-select__menu-item"
+    onClick={[Function]}
+  >
+    <div
+      className="gds-multi-select__menu-link"
+    >
+      <div
+        className="gds-form-group gds-multi-select__option"
+        onClick={[Function]}
+      >
+        <Checkbox
+          checked={false}
+          label="Foo"
+          onChange={[Function]}
+          size="xs"
+        >
+          <div
+            className="gds-form-group__checkbox gds-form-group__checkbox--xs"
+          >
+            <label
+              className="gds-form-group__checkbox-label"
+            >
+              <input
+                checked={false}
+                className="gds-form-group__checkbox-input"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <span
+                className="gds-form-group__checkbox-indicator"
+              />
+              Foo
+            </label>
+          </div>
+        </Checkbox>
+      </div>
+    </div>
+  </li>
+</MultiSelectMenuItem>
+`;

--- a/_tests/utils/deprecate.test.js
+++ b/_tests/utils/deprecate.test.js
@@ -1,0 +1,42 @@
+/* globals mount */
+import { deprecateLog, deprecateFunction } from '../../components/utils/deprecate';
+
+const log = console.log;
+
+describe('Expect', () => {
+    beforeEach(() => {
+        console.log = log;
+    });
+
+    it('deprecateLog() to log a message only once', () => {
+        console.log = jest.fn();
+        deprecateLog('This is a deprecation warning');
+        deprecateLog('This is a deprecation warning'); // same
+        deprecateLog('This is a deprecation warning'); // same
+        expect(console.log).toHaveBeenCalledTimes(1);
+
+        deprecateLog('This is a different warning'); // new
+        expect(console.log).toHaveBeenCalledTimes(2);
+    });
+
+    it('deprecateFunction() to return nothing if a function is not provided', () => {
+        console.log = jest.fn();
+        const oldFunc = 'not a func';
+        const oldFuncDeprecated = deprecateFunction(oldFunc, "this is an old func so don't use it");
+        expect(oldFuncDeprecated).toEqual(undefined);
+    });
+
+    it('deprecateFunction() to return a function and to log a deprecation message when called', () => {
+        console.log = jest.fn();
+        const oldFunc = jest.fn();
+        const oldFuncDeprecated = deprecateFunction(oldFunc, "this is an old func so don't use it");
+        expect(oldFuncDeprecated).toEqual(expect.any(Function));
+
+        oldFuncDeprecated('foo', { bar: 'bat ' });
+        expect(oldFunc).toBeCalledWith('foo', { bar: 'bat ' });
+
+        oldFuncDeprecated('bar', { bat: 'foo ' });
+        expect(oldFunc).toBeCalledWith('bar', { bat: 'foo ' });
+        expect(console.log).toHaveBeenCalledTimes(1);
+    });
+});

--- a/components/molecules/MultiSelect.jsx
+++ b/components/molecules/MultiSelect.jsx
@@ -1,12 +1,24 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Checkbox from './Checkbox';
+import MultiSelectSubMenu from './MultiSelectSubMenu';
+import MultiSelectMenuItem from './MultiSelectMenuItem';
 import cx from 'classnames';
 import generateUID from '../utils/generateUID';
+import updateOptions from '../utils/updateMultiSelectOptions';
+import { deprecateFunction } from '../utils/deprecate';
+
+const getSelectedOptions = options => {
+    const selected = options.reduce((acc, cur) => {
+        if (cur.options) {
+            return [...acc, ...getSelectedOptions(cur.options)];
+        }
+        return cur.selected ? [...acc, cur] : acc;
+    }, []);
+
+    return selected;
+};
 
 class MultiSelect extends Component {
-    uid = generateUID(this);
-
     state = {
         isOpen: false
     };
@@ -19,6 +31,12 @@ class MultiSelect extends Component {
         window.removeEventListener('click', this._closeOnClickOutside);
     }
 
+    uid = generateUID(this);
+
+    regionId = `MultiSelect_region_${this.uid}`;
+
+    labelId = `MultiSelect_label_${this.uid}`;
+
     _closeOnClickOutside = ({ target }) => {
         const el = this.container;
         if (!el.contains(target)) {
@@ -30,13 +48,44 @@ class MultiSelect extends Component {
 
     _getPlaceholder = () => {
         const { placeholder, options } = this.props;
-        const selectedOptions = options.filter(x => x.selected);
+        const selectedOptions = getSelectedOptions(options);
         return selectedOptions.map(x => x.name).join(', ') || placeholder;
     };
 
+    _handleSubChange = index => subItem => {
+        const options = this.props.options.map((item, i) => {
+            const shouldUpdate = i === index;
+            if (shouldUpdate) {
+                // sub options
+                const subOptions = updateOptions(item.options, subItem);
+                if (subOptions) {
+                    // update parent if all are selected/unselected
+                    const allSelected = !subOptions.map(opt => opt.selected).includes(false);
+                    return {
+                        ...item,
+                        selected: allSelected,
+                        options: subOptions
+                    };
+                }
+            }
+            return item;
+        });
+        this.props.onChange(options);
+    };
+
+    _handleChange = item => {
+        const options = updateOptions(this.props.options, item);
+        this.props.onChange(options);
+    };
+
     render() {
-        const { options, callback, placeholder, size, className, ...otherProps } = this.props;
+        const { options, callback, onChange, size, className, ...otherProps } = this.props;
         const { isOpen } = this.state;
+
+        const deprecatedCallback = deprecateFunction(
+            callback,
+            'The `callback` handler has been deprecated and will be removed in the next major version. Use `onChange` instead. See https://github.com/gumgum/gumdrops/blob/master/_stories/molecules/MultiSelect/README.md'
+        );
 
         const isSmall = size === 'sm';
         const isExtraSmall = size === 'xs';
@@ -52,43 +101,53 @@ class MultiSelect extends Component {
             'gds-multi-select__button--xs': isExtraSmall
         });
 
-        const regionId = `MultiSelect_region_${this.uid}`;
-        const labelId = `MultiSelect_label_${this.uid}`;
-
         return (
             <div className={rootClass} {...otherProps} ref={ref => (this.container = ref)}>
                 <button
                     aria-expanded={isOpen}
                     aria-pressed={isOpen}
-                    aria-controls={regionId}
+                    aria-controls={this.regionId}
                     tabIndex={0}
                     className={btnClass}
-                    id={labelId}
+                    id={this.labelId}
+                    name="multiselectMenu"
                     type="button"
                     onClick={this._toggleDropdown}>
                     <div className="-ellipsis">{this._getPlaceholder()}</div>
                 </button>
                 <ul
-                    aria-labelledby={labelId}
+                    aria-labelledby={this.labelId}
                     aria-hidden={!isOpen}
                     className="gds-multi-select__menu"
-                    id={regionId}
+                    id={this.regionId}
                     role="region">
-                    {options.map(({ name, value, selected }, index) => (
-                        <li key={`item-${index}`} className="gds-multi-select__menu-item">
-                            <div className="gds-multi-select__menu-link">
-                                <div className="gds-form-group gds-multi-select__option">
-                                    <Checkbox
-                                        label={name}
-                                        checked={selected}
-                                        onChange={event => {
-                                            callback(index, value, !selected);
-                                        }}
-                                    />
-                                </div>
-                            </div>
-                        </li>
-                    ))}
+                    {options.map(
+                        ({ name, value, selected, options: subOptions }, index) =>
+                            subOptions ? (
+                                <MultiSelectSubMenu
+                                    key={`menu-item-${index}`}
+                                    name={name}
+                                    index={index}
+                                    value={value}
+                                    selected={selected}
+                                    options={subOptions}
+                                    onChange={this._handleChange}
+                                    onSubChange={this._handleSubChange(index)}
+                                    size={size}
+                                />
+                            ) : (
+                                <MultiSelectMenuItem
+                                    key={`menu-item-${index}`}
+                                    name={name}
+                                    index={index}
+                                    value={value}
+                                    selected={selected}
+                                    callback={deprecatedCallback}
+                                    onChange={this._handleChange}
+                                    size={size}
+                                />
+                            )
+                    )}
                 </ul>
             </div>
         );
@@ -98,8 +157,22 @@ class MultiSelect extends Component {
 MultiSelect.displayName = 'MultiSelect';
 
 MultiSelect.propTypes = {
-    options: PropTypes.arrayOf(PropTypes.object).isRequired,
-    callback: PropTypes.func.isRequired,
+    options: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            value: PropTypes.any,
+            selected: PropTypes.bool,
+            options: PropTypes.arrayOf(
+                PropTypes.shape({
+                    name: PropTypes.string.isRequired,
+                    value: PropTypes.any,
+                    selected: PropTypes.bool
+                })
+            )
+        })
+    ).isRequired,
+    callback: PropTypes.func,
+    onChange: PropTypes.func,
     placeholder: PropTypes.string,
     size: PropTypes.oneOf(['xs', 'sm', '']),
     className: PropTypes.string

--- a/components/molecules/MultiSelectMenuItem.jsx
+++ b/components/molecules/MultiSelectMenuItem.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Checkbox from './Checkbox';
+import cx from 'classnames';
+
+const baseClass = 'gds-multi-select__menu-link';
+
+const MultiSelectMenuItem = ({
+    callback,
+    children,
+    index,
+    isActive,
+    name,
+    onChange,
+    onClick,
+    size,
+    selected,
+    subOptions,
+    value
+}) => (
+    <li className="gds-multi-select__menu-item" onClick={onClick}>
+        <div
+            className={cx(baseClass, {
+                [`${baseClass}--collapsable`]: children,
+                [`${baseClass}--active`]: isActive
+            })}>
+            <div
+                className="gds-form-group gds-multi-select__option"
+                onClick={event => event.stopPropagation()}>
+                <Checkbox
+                    label={name}
+                    checked={selected}
+                    size={size}
+                    onChange={() => {
+                        callback && callback(index, value, !selected);
+                        onChange &&
+                            onChange({ index, value, selected: !selected, options: subOptions });
+                    }}
+                />
+            </div>
+            {children}
+        </div>
+    </li>
+);
+
+MultiSelectMenuItem.propTypes = {
+    name: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    isActive: PropTypes.bool,
+    size: PropTypes.string,
+    value: PropTypes.any,
+    selected: PropTypes.bool,
+    children: PropTypes.node,
+    callback: PropTypes.func,
+    onChange: PropTypes.func,
+    onClick: PropTypes.func,
+    subOptions: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            value: PropTypes.any,
+            selected: PropTypes.bool
+        })
+    )
+};
+
+export default MultiSelectMenuItem;

--- a/components/molecules/MultiSelectSubMenu.jsx
+++ b/components/molecules/MultiSelectSubMenu.jsx
@@ -1,0 +1,70 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Checkbox from './Checkbox';
+import MultiSelectMenuItem from './MultiSelectMenuItem';
+
+class MultiSelectSubMenu extends Component {
+    state = {
+        isOpen: true
+    };
+
+    _toggleOpen = event => {
+        event.stopPropagation();
+        this.setState(({ isOpen }) => ({ isOpen: !isOpen }));
+    };
+
+    render() {
+        const { isOpen } = this.state;
+        const { options, onSubChange, size, ...rest } = this.props;
+        return (
+            <MultiSelectMenuItem
+                {...rest}
+                isActive={isOpen}
+                size={size}
+                subOptions={options}
+                onClick={this._toggleOpen}>
+                <ul className="gds-multi-select__sub-menu">
+                    {options.map(({ name, value, selected }, index) => (
+                        <li
+                            key={`item-${index}`}
+                            className="gds-multi-select__menu-item"
+                            onClick={event => event.stopPropagation()}>
+                            <div className="gds-multi-select__menu-link">
+                                <div className="gds-form-group gds-multi-select__option">
+                                    <Checkbox
+                                        label={name}
+                                        size={size}
+                                        checked={selected}
+                                        onChange={() => {
+                                            onSubChange({ index, value, selected: !selected });
+                                        }}
+                                    />
+                                </div>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </MultiSelectMenuItem>
+        );
+    }
+}
+
+MultiSelectSubMenu.propTypes = {
+    name: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    size: PropTypes.string,
+    value: PropTypes.any,
+    selected: PropTypes.bool,
+    children: PropTypes.node,
+    options: PropTypes.arrayOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            value: PropTypes.any,
+            selected: PropTypes.bool
+        })
+    ).isRequired,
+    onChange: PropTypes.func.isRequired,
+    onSubChange: PropTypes.func.isRequired
+};
+
+export default MultiSelectSubMenu;

--- a/components/molecules/Table.jsx
+++ b/components/molecules/Table.jsx
@@ -8,6 +8,7 @@ import Heading from './TableHeading';
 import Body from './TableBody';
 import Row from './TableRow';
 import Data from './TableData';
+import { deprecateLog } from '../utils/deprecate';
 
 const sortDirection = {
     ASC: 'asc',
@@ -102,8 +103,8 @@ class Table extends Component {
                                 // NOTE: onHeadingClick should be removed in the next major version
                                 // Using "headingProps" will allow more complete customization
                                 if (onHeadingClick) {
-                                    console.warn(
-                                        'Warning: `onHeadingClick` has been deprecated in favor of `headingProps`. Use `headingProps.onClick` instead.'
+                                    deprecateLog(
+                                        '`onHeadingClick` has been deprecated in favor of `headingProps`. Use `headingProps.onClick` instead. See https://github.com/gumgum/gumdrops/blob/master/_stories/molecules/Table/README.md#columns'
                                     );
                                 }
 

--- a/components/utils/deprecate.js
+++ b/components/utils/deprecate.js
@@ -1,0 +1,22 @@
+export const deprecateLog = (function() {
+    const hash = {};
+    return function(message) {
+        if (typeof message !== 'string') {
+            throw new Error('Must provide a string as a message');
+        }
+
+        if (!hash[message]) {
+            console.log('%cGumdrops %cWarning:', 'color: #00a7cf', 'color: #e5a516', message); // eslint-disable-line no-console
+            hash[message] = true;
+        }
+    };
+})();
+
+export const deprecateFunction = function(fn, message) {
+    if (typeof fn !== 'function') return;
+
+    return function(...args) {
+        fn(...args);
+        deprecateLog(message);
+    };
+};

--- a/components/utils/updateMultiSelectOptions.js
+++ b/components/utils/updateMultiSelectOptions.js
@@ -1,0 +1,35 @@
+const updateAllOptions = (options, selected) =>
+    options.map(item => ({
+        ...item,
+        selected
+    }));
+
+const updateNestedOptions = (options, item) =>
+    options.map((option, i) => {
+        if (!option.options) {
+            return {
+                ...option,
+                selected: i === item.index ? item.selected : option.selected
+            };
+        }
+
+        return {
+            ...option,
+            selected: i === item.index ? item.selected : option.selected,
+            options:
+                i === item.index ? updateAllOptions(item.options, item.selected) : option.options
+        };
+    });
+
+export default function updateOptions(options, item) {
+    const hasSubOptions = item.options;
+
+    if (hasSubOptions) {
+        return updateNestedOptions(options, item);
+    }
+
+    return options.map((option, i) => ({
+        ...option,
+        selected: i === item.index ? item.selected : option.selected
+    }));
+}


### PR DESCRIPTION
This addresses #27 

Design System Reference - http://ds.gumgum.com/stable/#gds-multi-select

## Features
- Sub menu options to be default opened at all times
- Checking/Unchecking on a parent category updates all the children
- Can check or uncheck a subcategory on its own without the parent
- Parent is updated if all children are checked/unchecked
- Supports one layer of nesting. 

## Changes
-  Adds a new `onChange` handler that should replace the existing `callback` handler. This will be called with the updated list of options, so there's no longer a need to update the list manually.
- Deprecated `callback`
- Added two new components to handle the checked options and state
    - `<MultiSelectSubMenu/>` - Handles the dropdown portion of the UI and the checked option
    - `<MultiSelectMenuItem/>` - Handles the markup for the checked option
- Added some utility functions that help update options list in `updateMultiSelectOptions.js`
- Added `deprecateFunction` and `deprecateLog` helpers

## @TODO

~~Still wan't to address some things. Just opening the PR in case there are opinions.~~

- [x] Deprecate `callback`: update documentation, and add logging
- [x] Write some UI tests
- [x] ARIA support (mostly works currently, keyboard accessible)
- [x] Fix the UI dropdown being toggled open/close unintentionally (not sure why).
