### PR TITLE
remove DS from manager head

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,1 +1,0 @@
-<link rel="stylesheet" href="https://assets.ggops.com/stable/theme-blue.css">


### PR DESCRIPTION
Fix resizing 🔥 🔥 🔥 

Removes DS styles from the manager head. This was adding our styles outside the iframe and causing a conflict with Storybook styles. Specifically this style: 

```css
* { position: relative }
```