### PR TITLE
#3 added block option

### DIFF
--- a/_stories/atoms/Button/README.md
+++ b/_stories/atoms/Button/README.md
@@ -1,1 +1,11 @@
-The `<Button>` component wraps any arbitrary components or JSX markup into a clickable button. The component also accepts any other props you would like to pass in, for example, `title="my button"`.
+## Props
+
+The following props may be passed to configure the button. All additional props are passed through to the `<button>` element:
+
+| name      | type      | description                                                                     | default   |
+| --------- | --------- | ------------------------------------------------------------------------------- | --------- |
+| className | `String`  | Additional class to be added to the outermost element                           |           |
+| isBlock   | `Boolean` | Indicate if this is a block element button                                      | `false`   |
+| isGroup   | `Boolean` | Indicate if this part of a button group                                         | `false`   |
+| size      | `String`  | Indicate the size of the button. One of `xs`, `sm` or `lg`                      |           |
+| context   | `String`  | Indicate the context of the button. Example `default`, `warning`, `danger` etc. | `default` |

--- a/_stories/atoms/Button/index.js
+++ b/_stories/atoms/Button/index.js
@@ -29,7 +29,8 @@ const component = () => (
         type={text('Type', 'button')}
         size={optionalSelect('Size', sizeOptions, '')}
         context={select('Context', contextOptions, 'default')}
-        group={boolean('Group', false)}
+        isGroup={boolean('isGroup', false)}
+        isBlock={boolean('isBlock', false)}
         onClick={action('button_clicked')}
         className={text('ClassName', '')}
         style={object('Style', {})}>

--- a/_tests/atoms/Button.test.js
+++ b/_tests/atoms/Button.test.js
@@ -3,7 +3,8 @@ import React from 'react';
 import Button from '../../components/atoms/Button';
 
 const defaultProps = {
-    group: false,
+    isGroup: false,
+    isBlock: false,
     size: 'sm',
     onClick: () => {},
     text: 'This is text',
@@ -24,7 +25,16 @@ describe('Expect <Button>', () => {
     it('to renders as a group button', () => {
         const props = {
             ...defaultProps,
-            group: true
+            isGroup: true
+        };
+        const wrapper = mount(<Button {...props}>My Cool Button</Button>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it('to renders as a blocked button', () => {
+        const props = {
+            ...defaultProps,
+            isBlock: true
         };
         const wrapper = mount(<Button {...props}>My Cool Button</Button>);
         expect(wrapper).toMatchSnapshot();

--- a/_tests/atoms/__snapshots__/Button.test.js.snap
+++ b/_tests/atoms/__snapshots__/Button.test.js.snap
@@ -4,7 +4,8 @@ exports[`Expect <Button> to render 1`] = `
 <Button
   className="foo-class"
   context="danger"
-  group={false}
+  isBlock={false}
+  isGroup={false}
   onBlur={[Function]}
   onClick={[Function]}
   size="sm"
@@ -33,11 +34,46 @@ exports[`Expect <Button> to render 1`] = `
 </Button>
 `;
 
+exports[`Expect <Button> to renders as a blocked button 1`] = `
+<Button
+  className="foo-class"
+  context="danger"
+  isBlock={true}
+  isGroup={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  size="sm"
+  style={
+    Object {
+      "width": "1000px",
+    }
+  }
+  text="This is text"
+  type="button"
+>
+  <button
+    className="gds-button foo-class gds-button--danger gds-button--sm gds-button--block"
+    onBlur={[Function]}
+    onClick={[Function]}
+    style={
+      Object {
+        "width": "1000px",
+      }
+    }
+    text="This is text"
+    type="button"
+  >
+    My Cool Button
+  </button>
+</Button>
+`;
+
 exports[`Expect <Button> to renders as a group button 1`] = `
 <Button
   className="foo-class"
   context="danger"
-  group={true}
+  isBlock={false}
+  isGroup={true}
   onBlur={[Function]}
   onClick={[Function]}
   size="sm"

--- a/components/atoms/Button.jsx
+++ b/components/atoms/Button.jsx
@@ -6,7 +6,9 @@ const Button = ({
     context,
     type,
     size,
+    isGroup,
     group,
+    isBlock,
     onClick,
     className,
     style,
@@ -18,7 +20,8 @@ const Button = ({
     const rootClass = cx(baseClass, className, {
         [`${baseClass}--${context}`]: context,
         [`${baseClass}--${size}`]: size,
-        [`${baseClass}-group__button`]: group
+        [`${baseClass}-group__button`]: isGroup || group,
+        [`${baseClass}--block`]: isBlock
     });
 
     return (
@@ -33,7 +36,9 @@ Button.displayName = 'Button';
 Button.defaultProps = {
     context: 'default',
     type: 'button',
+    isGroup: false,
     group: false,
+    isBlock: false,
     onClick: null,
     style: {}
 };
@@ -44,7 +49,9 @@ Button.propTypes = {
     type: PropTypes.string,
     /** xs, sm, lg */
     size: PropTypes.oneOf(['xs', 'sm', 'lg']),
+    isGroup: PropTypes.bool,
     group: PropTypes.bool,
+    isBlock: PropTypes.bool,
     onClick: PropTypes.func,
     className: PropTypes.string,
     style: PropTypes.object,


### PR DESCRIPTION
Added `block` prop to `Button` component. When passed as true the appropriate className is displayed.
Updated tests and snapshots