### PR TITLE
fix build script errors

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -198,7 +198,12 @@ function runNPMProcess(script, ...args) {
             fullError += err.toString();
         });
         childProcess.on('error', reject);
-        childProcess.on('close', () => (fullError ? reject(fullError) : resolve(stdOut)));
+        childProcess.on('close', code => {
+            if (code !== 0) {
+                return reject(fullError);
+            }
+            return resolve(stdOut);
+        });
     });
 }
 


### PR DESCRIPTION
Running `yarn build` resulted in the script finishing with errors and not creating a `tgz`:
```
---- Finding files in .components/ directory ----
---- Running Tests ----
✅ Tests Pass
---- Building modules ----
---- Please wait ----
---- Generating extra files ----
---- Packing dist/ directory ----
---- Finished with errors:  ----
npm notice
npm notice 📦  gumdrops@1.6.0
npm notice === Tarball Contents ===
npm notice 401B    package.json
npm notice 1.9kB   Accordion.js
...
```

I think this is because npm writes notices to `stderr` now – not sure if this is new behavior but I don't remember this failing before. 

I've updated it to only reject if there's an error code other than 0.