### PR TITLE
compare `isOpen` prop in AccordionItem before updating state

### DIFF
--- a/_stories/molecules/Accordion/README.md
+++ b/_stories/molecules/Accordion/README.md
@@ -1,16 +1,27 @@
 The `<Accordion>` component is a collapsible container for holding related elements. Nest `<AccordionItem>` components inside `<Accordion>` for each drawer. Nest `<AccordionItemContent>` in each `<AccordionItem>` if you would like to display listed information within an open `<AccordionItem>`. Each `<Accordion>` related component accepts a className and otherProps so you are able to further customize the component.
 
-## Props
+## Accordion Props
 
-The following props may be passed to configure the Accordion:
+The following props may be passed to configure the `<Accordion/>`:
 
-| name      | type      | description                                                                     | Required |
-| --------- | --------- | ------------------------------------------------------------------------------- | -------- |
-| children  | `Node`    | Children should be `<AccordionItem>`                                            | Yes      |
-| context   | `String`  | Indicate the context of the Accordion. One of `dark`, `white`, or `undefined`   |          |
-| allOpen   | `Boolean` | Indicate if all `<AccordionItem>` children should be opened or closed           |          |
-| allLocked | `Boolean` | Indicate if all `<AccordionItem>` children will be locked either open or closed |          |
-| size      | `String`  | Indicate the size of the Accordion. One of `sm` or `undefined`                  |          |
+| name           | type      | description                                                                             | Required |
+| -------------- | --------- | --------------------------------------------------------------------------------------- | -------- |
+| children       | `Node`    | Children should be `<AccordionItem>`                                                    | Yes      |
+| context        | `String`  | Indicate the context of the Accordion. One of `dark`, `white`, or `undefined`           |          |
+| initialAllOpen | `Boolean` | Indicate if all `<AccordionItem>` children should be opened or closed on initial mount. |          |
+| size           | `String`  | Indicate the size of the Accordion. One of `sm` or `undefined`                          |          |
+
+## AccordionItem Props
+
+The following props may be passed to configure the individual `<AccordionItem />` components:
+
+| name     | type      | description                                                                       |
+| -------- | --------- | --------------------------------------------------------------------------------- |
+| context  | `String`  | Indicate the context of the AccordionItem. One of `dark`, `white`, or `undefined` |
+| isOpen   | `Boolean` | Indicate if the item should be opened or closed on initial mount.                 |
+| isLocked | `Boolean` | Indicate if the item should be locked open or closed and ignore user interaction  |
+| label    | `String`  | The text label for an item                                                        |
+| size     | `String`  | Indicate the size of the AccordionItem. One of `sm` or `undefined`                |
 
 ## Examples
 

--- a/_stories/molecules/Accordion/index.js
+++ b/_stories/molecules/Accordion/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { text, boolean } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { optionalSelect } from '../../../components/utils/optionalSelect';
 
 import readme from './README.md';
@@ -22,10 +22,11 @@ const contextOptions = {
 const component = () => (
     <Accordion
         size={optionalSelect('Size', sizeOptions, '')}
-        allOpen={boolean('allOpen', false)}
-        allLocked={boolean('allLocked', false)}
         context={optionalSelect('Context', contextOptions, '')}
         className={text('Class', '')}>
+        <AccordionItem label="I'm locked open" isLocked isOpen>
+            <AccordionItemContent>Locked Content</AccordionItemContent>
+        </AccordionItem>
         <AccordionItem label={text('Item Label 1', 'Item 1')}>
             <AccordionItemContent>Content 1</AccordionItemContent>
         </AccordionItem>
@@ -34,10 +35,8 @@ const component = () => (
         </AccordionItem>
         <AccordionItem label={text('Item Label 3', 'Item 3')}>
             <AccordionItemContent>Content 3</AccordionItemContent>
-            <Accordion
-                size={optionalSelect('Size', sizeOptions, '')}
-                context={optionalSelect('Context', contextOptions, '')}>
-                <AccordionItem label={text('Nested Item Label 1', 'Nested Item 1')} isLocked>
+            <Accordion>
+                <AccordionItem label="Nested Item">
                     <AccordionItemContent>Nested Content</AccordionItemContent>
                 </AccordionItem>
             </Accordion>

--- a/_tests/molecules/Accordion.test.js
+++ b/_tests/molecules/Accordion.test.js
@@ -22,7 +22,7 @@ describe('Expect <Accordion>', () => {
 
     it('to render expanded', () => {
         const props = {
-            allOpen: true
+            initialAllOpen: true
         };
         const wrapper = mount(
             <Accordion {...props}>
@@ -34,29 +34,17 @@ describe('Expect <Accordion>', () => {
         wrapper.find('AccordionItem li').forEach(item => {
             expect(item.hasClass('gds-accordion__item--active')).toBe(true);
         });
-        wrapper.setProps({ allOpen: false });
-        wrapper.find('AccordionItem li').forEach(item => {
-            expect(item.hasClass('gds-accordion__item--active')).toBe(false);
-        });
     });
 
     it('to render locked', () => {
-        const props = {
-            allLocked: false
-        };
-
         const wrapper = mount(
-            <Accordion {...props}>
-                <AccordionItem label="Accordion Item 1" />
-                <AccordionItem label="Accordion Item 2" />
-                <AccordionItem label="Accordion Item 3" />
+            <Accordion>
+                <AccordionItem label="Accordion Item 1" isLocked />
+                <AccordionItem label="Accordion Item 2" isLocked />
+                <AccordionItem label="Accordion Item 3" isLocked />
             </Accordion>
         );
 
-        wrapper.find('AccordionItem li').forEach(item => {
-            expect(item.find('.gds-accordion__item-icon').length).toBe(1);
-        });
-        wrapper.setProps({ allLocked: true });
         wrapper.find('AccordionItem li').forEach(item => {
             expect(item.find('.gds-accordion__item-icon').length).toBe(0);
         });

--- a/components/atoms/AccordionItem.jsx
+++ b/components/atoms/AccordionItem.jsx
@@ -9,12 +9,6 @@ class AccordionItem extends Component {
         isOpen: this.props.isOpen
     };
 
-    static getDerivedStateFromProps({ isOpen }) {
-        return {
-            isOpen
-        };
-    }
-
     uid = generateUID(this);
 
     toggleOpen = event => {

--- a/components/molecules/Accordion.jsx
+++ b/components/molecules/Accordion.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const Accordion = ({ children, context, size, className, allOpen, allLocked, ...otherProps }) => {
+const Accordion = ({ children, context, size, className, initialAllOpen, ...otherProps }) => {
     const rootClass = cx('gds-accordion', className, {
         [`gds-accordion--${context}`]: context
     });
@@ -11,8 +11,7 @@ const Accordion = ({ children, context, size, className, allOpen, allLocked, ...
         return React.cloneElement(child, {
             context,
             size,
-            isOpen: allOpen,
-            isLocked: allLocked
+            isOpen: child.props.isOpen ? child.props.isOpen : initialAllOpen
         });
     });
 
@@ -29,8 +28,7 @@ Accordion.propTypes = {
     children: PropTypes.node.isRequired,
     /** dark, white */
     context: PropTypes.string,
-    allOpen: PropTypes.bool,
-    allLocked: PropTypes.bool,
+    initialAllOpen: PropTypes.bool,
     /** sm */
     size: PropTypes.oneOf(['sm']),
     className: PropTypes.string


### PR DESCRIPTION
Removes getDerivedStateFromProps. The component should not be controlled externally. Only able to set initial state on mount with `isOpen` prop