### PR TITLE
64 update pagination xs size

### DIFF
--- a/_stories/molecules/Pagination/index.js
+++ b/_stories/molecules/Pagination/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { number, boolean, select } from '@storybook/addon-knobs';
+import { number, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
+import { optionalSelect } from '../../../components/utils/optionalSelect';
 
 import readme from './README.md';
 import Pagination from '../../../components/molecules/Pagination';
 
-const sizeOptions = ['xl', 'lg', 'sm', 'xs', ''];
+const sizeOptions = { xl: 'xl', lg: 'lg', sm: 'sm', xs: 'xs', 'No Value': '' };
 
 class TestPagination extends React.Component {
     state = {
@@ -28,7 +29,7 @@ class TestPagination extends React.Component {
                 lastPage={number('Last Page', lastPage)}
                 boundaries={boolean('Show Boundaries', false)}
                 justify={boolean('Justify', false)}
-                size={select('Size', sizeOptions, '')}
+                size={optionalSelect('Size', sizeOptions, '')}
                 onChange={this.handlePageChange}
             />
         );

--- a/_tests/molecules/__snapshots__/Pagination.test.js.snap
+++ b/_tests/molecules/__snapshots__/Pagination.test.js.snap
@@ -29,6 +29,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -54,6 +55,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -75,6 +77,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -96,6 +99,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -117,6 +121,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -138,6 +143,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -159,6 +165,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -180,6 +187,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -201,6 +209,7 @@ exports[`Expect <Pagination> to render 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": 0,
           }
         }
@@ -248,6 +257,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -273,6 +283,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -294,6 +305,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -315,6 +327,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -336,6 +349,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -357,6 +371,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -378,6 +393,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -399,6 +415,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }
@@ -420,6 +437,7 @@ exports[`Expect <Pagination> to render with boundaries and justify 1`] = `
             "background": "none",
             "border": 0,
             "fontFamily": "inherit",
+            "height": "",
             "padding": null,
           }
         }

--- a/components/molecules/Pagination.jsx
+++ b/components/molecules/Pagination.jsx
@@ -116,7 +116,8 @@ class Pagination extends Component {
             border: 0,
             fontFamily: 'inherit',
             padding: justify ? null : 0,
-            background: 'none'
+            background: 'none',
+            height: size === 'xs' ? '1.5rem' : ''
         };
 
         const shouldRender = lastPage > 1 && activePage > 0 && activePage <= lastPage;


### PR DESCRIPTION
i updated the storybook pagination component to show the size selects (was broken).

we noticed while working on ad manager that the xs sizes did not align correctly, so this adds a height to xs sizes to properly fit the parent container.

https://feature-64-update-pagination-xs-size-gumdrops-gumgum.surge.sh/?selectedKind=Molecules&selectedStory=Pagination&full=0&addons=1&stories=1&panelRight=1&addonPanel=storybooks%2Fstorybook-addon-knobs