### PR TITLE
68 add cursor pointer to divider

### DIFF
--- a/components/molecules/Divider.jsx
+++ b/components/molecules/Divider.jsx
@@ -14,7 +14,7 @@ const Divider = ({
     const baseClass = 'gds-divider';
     const rootClass = cx(baseClass, className, {
         [`${baseClass}--${centered}`]: centered,
-        [`${baseClass}--${collapsible}`]: collapsible
+        [`${baseClass}--${collapsible} -cursor--pointer`]: collapsible
     });
 
     const arrowClasses = cx(`${baseClass}__arrow`, {


### PR DESCRIPTION
small update, if the divider has the option to be collapsible, the cursor should change to pointer so the user knows it's clickable.