### PR TITLE
Allow to select a default value for a RadioGroup

### DIFF
--- a/_stories/molecules/RadioGroup/README.md
+++ b/_stories/molecules/RadioGroup/README.md
@@ -11,6 +11,7 @@ The following props may be passed to configure the Radio Group. All additional p
 | onChange  | `Function` |          | Change handler that will be called when a change event happens on a `<RadioButton>`. |
 | options   | `Array`    | true     | Radio button options list. An array of objects with `label` and `value` properties.  |
 | size      | `String`   |          | Indicate the size of the button. One of `xs` or `sm`.                                |
+| defaultValue | `String or Boolean or Number`|| Select a value by default from the options                                  |
 
 ## Example
 

--- a/_stories/molecules/RadioGroup/index.js
+++ b/_stories/molecules/RadioGroup/index.js
@@ -26,6 +26,7 @@ const component = () => (
         context={optionalSelect('Context', contextOptions, '')}
         name="my-radio-group"
         options={[{ label: 'Foo', value: 'foo' }, { label: 'Bar', value: 'bar' }]}
+        defaultValue="bar"
     />
 );
 

--- a/_tests/molecules/__snapshots__/RadioGroup.test.js.snap
+++ b/_tests/molecules/__snapshots__/RadioGroup.test.js.snap
@@ -7,6 +7,7 @@ exports[`Expect <RadioGroup> to render 1`] = `
   <RadioButton
     className="-m-r-4"
     context="success"
+    defaultChecked={false}
     key="option-0"
     label="Cool"
     name="radio-buttons"

--- a/components/molecules/RadioGroup.jsx
+++ b/components/molecules/RadioGroup.jsx
@@ -3,7 +3,7 @@ import RadioButton from '../atoms/RadioButton';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 
-const RadioGroup = ({ context, size, options, onChange, onBlur, name, className, ...rest }) => {
+const RadioGroup = ({ context, size, options, onChange, onBlur, name, className, defaultValue, ...rest }) => {
     const baseClass = 'gds-form-group__radio';
 
     const rootClass = cx(baseClass, className, {
@@ -22,6 +22,7 @@ const RadioGroup = ({ context, size, options, onChange, onBlur, name, className,
                     context={context}
                     onChange={onChange}
                     value={value}
+                    defaultChecked={defaultValue === value}
                     {...rest}
                 />
             ))}
@@ -43,7 +44,8 @@ RadioGroup.propTypes = {
                 .isRequired,
             label: PropTypes.string.isRequired
         })
-    ).isRequired
+    ).isRequired,
+    defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
 };
 
 export default RadioGroup;


### PR DESCRIPTION
This was made with Mahdiye

Do add a default value to a RadioGroup element, simply add `defaultValue` as a props. The value should match one of the value in the options array