### PR TITLE
Hotfix/table column fix

### DIFF
--- a/_tests/molecules/Table.test.js
+++ b/_tests/molecules/Table.test.js
@@ -5,6 +5,8 @@ import renderer from 'react-test-renderer';
 import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
 import Table from '../../components/molecules/Table';
+import TableBody from '../../components/molecules/TableBody';
+import TableData from '../../components/molecules/TableData';
 
 const defaultProps = {
     data: [
@@ -115,6 +117,17 @@ test('Expect <Table> to manually set sort direction', () => {
 
     const heading = getByText('Foo');
     expect(heading).toHaveClass('gds-table__header--sort-asc');
+});
+
+test('Expect <Table> to render when used without columns prop', () => {
+    const tree = renderer.create(<Table>
+        <TableBody>
+            <TableData>
+                Foo
+            </TableData>
+        </TableBody>
+    </Table>).toJSON();
+    expect(tree).toMatchSnapshot();
 });
 
 

--- a/_tests/molecules/__snapshots__/Table.test.js.snap
+++ b/_tests/molecules/__snapshots__/Table.test.js.snap
@@ -102,6 +102,22 @@ exports[`Expect <Table> to render using advanced configs 1`] = `
 </table>
 `;
 
+exports[`Expect <Table> to render when used without columns prop 1`] = `
+<table
+  className="gds-table"
+>
+  <tbody
+    className=""
+  >
+    <td
+      className=""
+    >
+      Foo
+    </td>
+  </tbody>
+</table>
+`;
+
 exports[`Expect <Table> to render with expandable rows 1`] = `
 <table
   className="gds-table custom-class gds-table--lg gds-table--expandable"

--- a/components/molecules/Table.jsx
+++ b/components/molecules/Table.jsx
@@ -147,7 +147,7 @@ class Table extends Component {
     }
 
     renderTableContent({
-        columns = [],
+        columns,
         isStriped,
         isInverse,
         hasHeader,
@@ -301,7 +301,7 @@ class Table extends Component {
     }
 
     renderTable() {
-        const { data, className, children, size, isStriped, isInverse, columns = [] } = this.props;
+        const { data, className, children, size, isStriped, isInverse, columns } = this.props;
         return (
             <table
                 className={cx('gds-table', className, {
@@ -413,7 +413,8 @@ Table.propTypes = {
 };
 
 Table.defaultProps = {
-    hasHeader: true
+    hasHeader: true,
+    columns: [],
 };
 
 export default Table;

--- a/components/molecules/Table.jsx
+++ b/components/molecules/Table.jsx
@@ -147,7 +147,7 @@ class Table extends Component {
     }
 
     renderTableContent({
-        columns = [],
+        columns,
         isStriped,
         isInverse,
         hasHeader,
@@ -301,7 +301,7 @@ class Table extends Component {
     }
 
     renderTable() {
-        const { data, className, children, size, isStriped, isInverse, columns = [] } = this.props;
+        const { data, className, children, size, isStriped, isInverse, columns } = this.props;
         return (
             <table
                 className={cx('gds-table', className, {

--- a/components/molecules/Table.jsx
+++ b/components/molecules/Table.jsx
@@ -147,7 +147,7 @@ class Table extends Component {
     }
 
     renderTableContent({
-        columns,
+        columns = [],
         isStriped,
         isInverse,
         hasHeader,
@@ -301,7 +301,7 @@ class Table extends Component {
     }
 
     renderTable() {
-        const { data, className, children, size, isStriped, isInverse, columns } = this.props;
+        const { data, className, children, size, isStriped, isInverse, columns = [] } = this.props;
         return (
             <table
                 className={cx('gds-table', className, {


### PR DESCRIPTION
When using the <Table /> component without the columns/data props (standalone mode) `columns.some` was failing as well as `columns.map` as the value is undefined. I've just set the default prop for columns to be an empty array.