### PR TITLE
PGA-254 - Updating logic so when table is expanded, height is set to …

### DIFF
--- a/components/molecules/Table.jsx
+++ b/components/molecules/Table.jsx
@@ -121,7 +121,9 @@ class Table extends Component {
             easing: 'ease-in-out'
         }).onfinish = () => {
             // always set the height after finish to the last value on the animatable properties
-            ref.style.height = toFrom[1].height;
+            // when expanded, we should set the height to auto to automatically account
+            // for dynamic changes to the content when resizing or changing the content based on state
+            ref.style.height = shouldExpand ? 'auto' : toFrom[1].height;
         };
     };
 


### PR DESCRIPTION
The expandable row logic is used within wrap-decks to show the tiles available for the specific entity, now that tiles are dynamic and can be added/ removed the height of the content is also more dynamic now, previously this component would assign a static height to the parent element after it was expanded, which is wrong in the case where content is removed / added after the expand action is complete.

Instead, after the expand animation has finished, it will now set the height to auto allowing the browser to automatically adjust to the flow of content.