### PR TITLE
Extended Table component to allow multiple footer rows and can disable row extend functionality at the cell level.

### DIFF
--- a/_tests/molecules/Table.test.js
+++ b/_tests/molecules/Table.test.js
@@ -254,7 +254,7 @@ test('Expect <Table> to render the table footer component as a JSX.Element', () 
         ],
         footer: <TableFooter data-testid="table-footer-manual">
             <TableRow>
-                <TableData colspan={2}>Footer!</TableData>
+                <TableData colSpan={2}>Footer!</TableData>
             </TableRow>
         </TableFooter>
     };
@@ -262,4 +262,76 @@ test('Expect <Table> to render the table footer component as a JSX.Element', () 
     const footer = queryByTestId('table-footer-manual');
     expect(footer).toBeInTheDocument();
     expect(footer).toMatchSnapshot();
+});
+
+test('Expect <Table> to render multiple footer rows', () => {
+    const props = {
+        ...defaultProps,
+        customRowKey: 'foo',
+        columns: [
+            {
+                key: 'foo',
+                children: 'Foo',
+                headingProps: { style: { width: 100, onClick: jest.fn() } }
+            },
+            {
+                key: 'bar',
+                children: 'Bar',
+                renderExpandableColumn(cellData) {
+                    return <div>Expandable - {cellData}</div>;
+                }
+            }
+        ],
+        footer: [
+            {
+                foo: 'Bar Footer 1',
+                bar: 'Foo Footer 1'
+            },
+            {
+                foo: 'Bar Footer 2',
+                bar: 'Foo Footer 2'
+            }
+        ]
+    };
+    const { queryByTestId } = render(<Table {...props} />);
+    const footer = queryByTestId('table-footer');
+    expect(footer).toBeInTheDocument();
+    expect(footer.querySelectorAll('tr')).toHaveLength(2);
+    expect(footer).toMatchSnapshot();
+});
+
+test('Expect <Table> to use a custom expandable trigger', () => {
+    const props = {
+        ...defaultProps,
+        customRowKey: 'foo',
+        columns: [
+            {
+                key: 'foo',
+                children: 'Foo',
+                headingProps: { style: { width: 100, onClick: jest.fn() } }
+            },
+            {
+                key: 'bar',
+                children: 'Bar',
+                renderExpandableColumn(cellData) {
+                    return <div>Expandable - {cellData}</div>;
+                },
+                renderExpandableTrigger(cellData, key, rowData, column, { isExpanded, onToggle }) {
+                    return (
+                        <TableData key={key} onClick={onToggle}>
+                            {cellData} <i className={`fa fa-chevron-${isExpanded ? 'up' : 'down'}`} />
+                        </TableData>
+                    );
+                }
+            }
+        ]
+    };
+    const { queryByTestId } = render(<Table {...props} />);
+    const expandableRow = queryByTestId('expandable-row-Foo');
+    const triggerCell = queryByTestId('row-Foo-key-1');
+    expect(triggerCell).toHaveClass('chevron-expander');
+    expect(triggerCell).toHaveClass('collapsed');
+    fireEvent.click(triggerCell);
+    expect(triggerCell).toHaveClass('expanded');
+    expect(expandableRow.querySelector('.gds-table--collapsible').style.height).toEqual('100px');
 });

--- a/_tests/molecules/__snapshots__/Table.test.js.snap
+++ b/_tests/molecules/__snapshots__/Table.test.js.snap
@@ -76,6 +76,42 @@ exports[`Expect <Table> to render properly 1`] = `
 </table>
 `;
 
+exports[`Expect <Table> to render multiple footer rows 1`] = `
+<tfoot
+  class=""
+  data-testid="table-footer"
+>
+  <tr
+    class="gds-table__row"
+  >
+    <td
+      class=""
+    >
+      Bar Footer 1
+    </td>
+    <td
+      class=""
+    >
+      Foo Footer 1
+    </td>
+  </tr>
+  <tr
+    class="gds-table__row"
+  >
+    <td
+      class=""
+    >
+      Bar Footer 2
+    </td>
+    <td
+      class=""
+    >
+      Foo Footer 2
+    </td>
+  </tr>
+</tfoot>
+`;
+
 exports[`Expect <Table> to render the table footer component as a JSX.Element 1`] = `
 <tfoot
   class=""
@@ -217,3 +253,4 @@ exports[`Expect <Table> to render with expandable rows 1`] = `
   </tbody>
 </table>
 `;
+

--- a/stories/molecules/Table.mdx
+++ b/stories/molecules/Table.mdx
@@ -46,6 +46,7 @@ The `columns` prop config can take a number of more advanced configurations as s
 | sortCompareAsc         | `Function` | Custom ascending sort compare function. [See example](#custom-sorting-example)                                                                                  |
 | sortCompareDesc        | `Function` | Custom descending sort compare function. [See example](#custom-sorting-example)                                                                                 |
 | renderExpandableColumn | `Function` | Convert the cell to contain a button that will expand the returned content returned from this method. [See example](#custom-expandable-column)            |
+| renderExpandableTrigger | `Function` | Customize the cell used to trigger expansion. Called with the cell data, key, row data, column object, and an object containing `isExpanded` and `onToggle`. The returned element will automatically receive the `chevron-expander` class. |
 
 ### Custom Column Markup Example
 
@@ -184,6 +185,14 @@ const columns = [{
     renderExpandableColumn(cellData, key, rowData, column) {
         return <p>Hi my name is {cellData} and I'm {rowData.age} years old.</p>
     }
+    ,
+    renderExpandableTrigger(cellData, key, rowData, column, { isExpanded, onToggle }) {
+        return (
+            <TableData key={key} onClick={onToggle}>
+                {cellData} <i className={`fa fa-chevron-${isExpanded ? 'up' : 'down'}`} />
+            </TableData>
+        );
+    }
 }, {
     key: 'age',
     children: 'Age',
@@ -197,7 +206,7 @@ The table footer can be used to display totals or other summary information. The
 
 The footer will allow you to have a "static" row at the bottom of the table that will not be affected by sorting.
 
-The footer prop can accept JSX or an object containing a key/value pair object where the "keys" are the column keys.
+The footer prop can accept JSX, an object, or an array of objects containing key/value pairs where the "keys" are the column keys.
 
 The following example will create a table with a footer that will display the total age of all the people in the table.
 
@@ -215,6 +224,23 @@ const footer = {
     age: data.reduce((acc, row) => acc + row.age, 0) // -> 44
 }
 const People = () => <Table columns={columns} data={data} footer={footer} customRowKey="id" />;
+```
+
+Multiple footer rows can be provided by passing an array of objects:
+
+```jsx
+const multiFooter = [
+    {
+        name: 'Average Age',
+        age: data.reduce((acc, row) => acc + row.age, 0) / data.length
+    },
+    {
+        name: 'Total Count',
+        age: data.length
+    }
+];
+
+const People = () => <Table columns={columns} data={data} footer={multiFooter} customRowKey="id" />;
 ```
 
 

--- a/stories/molecules/Table.mdx
+++ b/stories/molecules/Table.mdx
@@ -36,17 +36,15 @@ const People = () => <Table columns={columns} data={data} />;
 
 The `columns` prop config can take a number of more advanced configurations as seen above. For more advanced configuration you can supply additional properties to the `columns` array:
 
-| property               | type       | description                                                                                                                                             |
-| ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| key                    | `String`   | Key representing the corresponding data property.                                                                                                       |
-| children               | `Node`     | Custom markup to render in the column heading [See example](#custom-column-markup-example)                                                                      |
-| disableSorting         | `Boolean`  | Disables ability to sort column data                                                                                                                    |
-| dataCellDecorator      | `Function` | Customize cell markup with a decorator, a function that is called with the cell data, a React key, and the row data. [See example](#custom-cell-markup-example) |
-| headingProps           | `Object`   | Props object to be passed to the `<TableHeading>` component. [See example](#custom-heading-props-example)                                                       |
-| sortCompareAsc         | `Function` | Custom ascending sort compare function. [See example](#custom-sorting-example)                                                                                  |
-| sortCompareDesc        | `Function` | Custom descending sort compare function. [See example](#custom-sorting-example)                                                                                 |
-| renderExpandableColumn | `Function` | Convert the cell to contain a button that will expand the returned content returned from this method. [See example](#custom-expandable-column)            |
-| renderExpandableTrigger | `Function` | Customize the cell used to trigger expansion. Called with the cell data, key, row data, column object, and an object containing `isExpanded` and `onToggle`. The returned element will automatically receive the `chevron-expander` class. |
+- `key`: Key representing the corresponding data property.
+- `children`: Custom markup to render in the column heading [See example](#custom-column-markup-example).
+- `disableSorting`: Disables ability to sort column data.
+- `dataCellDecorator`: Customize cell markup using a decorator—a function that receives cell data, a React key, and row data. [See example](#custom-cell-markup-example).
+- `headingProps`: Props object to be passed to the `<TableHeading>` component. [See example](#custom-heading-props-example).
+- `sortCompareAsc`: Custom ascending sort compare function. [See example](#custom-sorting-example).
+- `sortCompareDesc`: Custom descending sort compare function. [See example](#custom-sorting-example).
+- `renderExpandableColumn`: Convert the cell to contain a button that will expand the returned content from this method. [See example](#custom-expandable-column).
+- `renderExpandableTrigger`: Customize the cell used to trigger expansion. Called with the cell data, key, row data, column object, and an object containing `isExpanded` and `onToggle`. The returned element will automatically receive the `chevron-expander` class.
 
 ### Custom Column Markup Example
 

--- a/stories/molecules/Table.mdx
+++ b/stories/molecules/Table.mdx
@@ -200,6 +200,8 @@ const columns = [{
 
 const People = () => <Table columns={columns} data={data} customRowKey="id" />;
 ```
+Note: custom triggers will automatically receive the `chevron-expander` class so they match the default expand animation.
+
 ### Table Footer
 
 The table footer can be used to display totals or other summary information. The footer is rendered as a `<tfoot>` element.
@@ -264,7 +266,7 @@ const data = [
 function CustomFooter() {
     return <TableFooter>
         <TableRow>
-            <TableData colspan={2}>
+            <TableData colSpan={2}>
                 The average age is {data.reduce((acc, row) => acc + row.age, 0) / data.length}
             </TableData>
         </TableRow>

--- a/stories/molecules/Table.stories.js
+++ b/stories/molecules/Table.stories.js
@@ -68,6 +68,13 @@ const columnsExpandable = [
                     column
                 }, null, 2)}</pre>
             </div>)
+        },
+        renderExpandableTrigger(cellData, key, rowData, column, { isExpanded, onToggle }) {
+            return (
+                <TableData key={key} onClick={onToggle}>
+                    {cellData} <i className={`fa fa-chevron-${isExpanded ? 'up' : 'down'}`} />
+                </TableData>
+            );
         }
     },
     {
@@ -215,11 +222,20 @@ export const Footer = Template.bind({});
 Footer.args = {
     columns: columnsAdvanced,
     numOfRows: 5,
-    footer: {
-        id: '123',
-        name: '',
-        title: '',
-        age: 'Average Age: 30',
-        height: 'Average Height: 5\'8"',
-    }
+    footer: [
+        {
+            id: '123',
+            name: '',
+            title: '',
+            age: 'Average Age: 30',
+            height: 'Average Height: 5\'8"',
+        },
+        {
+            id: 'total',
+            name: 'Total Rows',
+            title: '',
+            age: 'Rows: 5',
+            height: ''
+        }
+    ]
 }


### PR DESCRIPTION
- Added support for customizing the cell used to trigger row expansion via a new renderExpandableTrigger property. The  trigger is executed with the cell data, key, row data and a helper object containing isExpanded and onToggle

- Footers now accept arrays of objects, enabling multiple footer rows to be rendered in <tfoot>

- Updated propTypes to mention the new trigger prop and allow the footer prop to be either an object or array of objects

- Documentation explains how to implement renderExpandableTrigger and demonstrates multi-row footers in the storybook docs

- Storybook examples showcase custom expandable triggers and multiple footer rows for clarity